### PR TITLE
Initial farmer implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,22 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1"
 bytesize = "1.1"
 either = "1.8"
 futures = "0.3"
 libp2p-core = "0.36"
 tempdir = "0.3"
 
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "8007a0acd57064264aa03a8c71eb1c9cc9466994" }
 subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "8007a0acd57064264aa03a8c71eb1c9cc9466994" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "8007a0acd57064264aa03a8c71eb1c9cc9466994" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "8007a0acd57064264aa03a8c71eb1c9cc9466994" }
 
 [dev-dependencies]
 tokio = { version = "1.21", features = ["rt-multi-thread", "macros"] }
+
+[patch.crates-io]
+# TODO: Remove once chacha20poly1305 0.10 appears in libp2p's dependencies
+chacha20poly1305 = { git = "https://github.com/RustCrypto/AEADs", rev = "06dbfb5571687fd1bbe9d3c9b2193a1ba17f8e99" }
+libp2p = { git = "https://github.com/subspace/rust-libp2p", branch = "subspace-v3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,17 +6,20 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
 async-trait = "0.1"
 bytesize = "1.1"
 either = "1.8"
 futures = "0.3"
 libp2p-core = "0.36"
 tempdir = "0.3"
+thiserror = "1"
+tokio = { version = "1.21", features = ["rt"] }
 
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "8007a0acd57064264aa03a8c71eb1c9cc9466994" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "8007a0acd57064264aa03a8c71eb1c9cc9466994" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "8007a0acd57064264aa03a8c71eb1c9cc9466994" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "8007a0acd57064264aa03a8c71eb1c9cc9466994" }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "0b47b586d30e2fbde94956d4f1b6473591954492" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "0b47b586d30e2fbde94956d4f1b6473591954492" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "0b47b586d30e2fbde94956d4f1b6473591954492" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "0b47b586d30e2fbde94956d4f1b6473591954492" }
 
 [dev-dependencies]
 tokio = { version = "1.21", features = ["rt-multi-thread", "macros"] }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -22,7 +22,7 @@ async fn main() {
         .build(
             reward_address,
             node.clone(),
-            PlotDescription::new("plot", ByteSize::gb(10)),
+            vec![PlotDescription::new("plot", ByteSize::gb(10))],
         )
         .await
         .expect("Failed to init a farmer");
@@ -68,7 +68,7 @@ async fn main() {
         .build(
             reward_address,
             node.clone(),
-            PlotDescription::new("plot", ByteSize::gb(10)),
+            vec![PlotDescription::new("plot", ByteSize::gb(10))],
         )
         .await
         .expect("Failed to init a farmer");

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -52,7 +52,7 @@ async fn main() {
     dbg!(farmer.get_info().await);
 
     farmer.stop_farming().await;
-    farmer.close().await;
+    farmer.close().await.expect("Failed to close the farmer");
     node.close().await;
 
     // Restarting
@@ -80,6 +80,6 @@ async fn main() {
     for plot in farmer.plots().await {
         plot.delete().await;
     }
-    farmer.wipe().await;
+    farmer.wipe().await.expect("Failed to wipe the farmer");
     node.wipe().await;
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -17,12 +17,12 @@ async fn main() {
 
     let reward_address = PublicKey::from([0; 32]);
     let mut farmer: Farmer = Farmer::builder()
-        .ws_rpc("127.0.0.1:9955".parse().unwrap())
-        .listen_on("/ip4/0.0.0.0/tcp/40333".parse().unwrap())
+        // .ws_rpc("127.0.0.1:9955".parse().unwrap())
+        // .listen_on("/ip4/0.0.0.0/tcp/40333".parse().unwrap())
         .build(
             reward_address,
             node.clone(),
-            vec![PlotDescription::new("plot", ByteSize::gb(10))],
+            &[PlotDescription::new("plot", ByteSize::gb(10))],
         )
         .await
         .expect("Failed to init a farmer");
@@ -68,7 +68,7 @@ async fn main() {
         .build(
             reward_address,
             node.clone(),
-            vec![PlotDescription::new("plot", ByteSize::gb(10))],
+            &[PlotDescription::new("plot", ByteSize::gb(10))],
         )
         .await
         .expect("Failed to init a farmer");

--- a/src/farmer.rs
+++ b/src/farmer.rs
@@ -56,14 +56,13 @@ impl Builder {
     }
 
     /// It supposed to open node at the supplied location
-    // TODO: Should we just require multiple plots?
     pub async fn build(
         self,
         reward_address: PublicKey,
         node: Node,
-        plot: PlotDescription,
+        plots: Vec<PlotDescription>,
     ) -> Result<Farmer, ()> {
-        let _ = (reward_address, node, plot);
+        let _ = (reward_address, node, plots);
         todo!()
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -119,3 +119,78 @@ impl Node {
         todo!()
     }
 }
+
+mod farmer_rpc_client {
+    use super::*;
+
+    use futures::Stream;
+    use std::pin::Pin;
+
+    use subspace_archiving::archiver::ArchivedSegment;
+    use subspace_core_primitives::{Piece, PieceIndex, RecordsRoot, SegmentIndex};
+    use subspace_farmer::rpc_client::{Error, RpcClient};
+    use subspace_rpc_primitives::{
+        FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
+    };
+
+    #[async_trait::async_trait]
+    impl RpcClient for Node {
+        async fn farmer_protocol_info(&self) -> Result<FarmerProtocolInfo, Error> {
+            todo!()
+        }
+
+        /// Subscribe to slot
+        async fn subscribe_slot_info(
+            &self,
+        ) -> Result<Pin<Box<dyn Stream<Item = SlotInfo> + Send + 'static>>, Error> {
+            todo!()
+        }
+
+        /// Submit a slot solution
+        async fn submit_solution_response(
+            &self,
+            solution_response: SolutionResponse,
+        ) -> Result<(), Error> {
+            let _ = solution_response;
+            todo!()
+        }
+
+        /// Subscribe to block signing request
+        async fn subscribe_reward_signing(
+            &self,
+        ) -> Result<Pin<Box<dyn Stream<Item = RewardSigningInfo> + Send + 'static>>, Error>
+        {
+            todo!()
+        }
+
+        /// Submit a block signature
+        async fn submit_reward_signature(
+            &self,
+            reward_signature: RewardSignatureResponse,
+        ) -> Result<(), Error> {
+            let _ = reward_signature;
+            todo!()
+        }
+
+        /// Subscribe to archived segments
+        async fn subscribe_archived_segments(
+            &self,
+        ) -> Result<Pin<Box<dyn Stream<Item = ArchivedSegment> + Send + 'static>>, Error> {
+            todo!()
+        }
+
+        /// Get records roots for the segments
+        async fn records_roots(
+            &self,
+            segment_indexes: Vec<SegmentIndex>,
+        ) -> Result<Vec<Option<RecordsRoot>>, Error> {
+            let _ = segment_indexes;
+            todo!()
+        }
+
+        async fn get_piece(&self, piece_index: PieceIndex) -> Result<Option<Piece>, Error> {
+            let _ = piece_index;
+            todo!()
+        }
+    }
+}


### PR DESCRIPTION
This pr implements initial farmer support (though not testable yet). Currently it supports only start of the farmer itself and stopping it via calling `Farmer::close` and `Farmer::wipe` (no drop check yet).

Closes #5 
Relates to #11 