### PR TITLE
Add wipe and require chain spec chain spec 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,12 @@ edition = "2021"
 anyhow = "1"
 async-trait = "0.1"
 bytesize = "1.1"
-dirs = "4"
-either = "1.8"
 futures = "0.3"
 jsonrpsee-core = "0.15.1"
 libp2p-core = "0.34"
 serde = "1"
-tempdir = "0.3"
 thiserror = "1"
-tokio = { version = "1.21", features = ["rt"] }
+tokio = { version = "1.21", features = ["fs", "rt"] }
 
 frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598" }
 sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598" }
@@ -46,6 +43,7 @@ system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "7
 
 [dev-dependencies]
 tokio = { version = "1.21", features = ["rt-multi-thread", "macros"] }
+tempdir = "0.3"
 
 [patch.crates-io]
 # TODO: Remove once chacha20poly1305 0.10 appears in libp2p's dependencies

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,14 +1,13 @@
 use bytesize::ByteSize;
 use futures::StreamExt;
-use subspace_sdk::{Chain, Farmer, Node, NodeMode, PlotDescription, PublicKey};
+use subspace_sdk::{chain_spec, Farmer, Node, NodeMode, PlotDescription, PublicKey};
 
 #[tokio::main]
 async fn main() {
     let mut node: Node = Node::builder()
         .mode(NodeMode::Full)
-        .chain(Chain::Gemini2a)
         .name("i1i1")
-        .build("node")
+        .build("node", chain_spec::gemini_2a().unwrap())
         .await
         .expect("Failed to init a node");
 
@@ -54,8 +53,7 @@ async fn main() {
     // Restarting
     let mut node = Node::builder()
         .mode(NodeMode::Full)
-        .chain(Chain::Gemini2a)
-        .build("node")
+        .build("node", chain_spec::gemini_2a().unwrap())
         .await
         .expect("Failed to init a node");
     node.sync().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub use farmer::{
     Builder as FarmerBuilder, Farmer, Info as NodeInfo, Plot, PlotDescription, Solution,
 };
 pub use node::{
-    chain_spec, Builder as NodeBuilder, Chain, Info as FarmerInfo, Mode as NodeMode, Node,
+    chain_spec, Builder as NodeBuilder, Info as FarmerInfo, Mode as NodeMode, Node,
 };
 pub use subspace_core_primitives::PublicKey;
 
@@ -21,12 +21,9 @@ mod tests {
     async fn test_integration() {
         let dir = TempDir::new("test").unwrap();
         let node = Node::builder()
-            .chain(Chain::Custom(Box::new(
-                node::chain_spec::dev_config().unwrap(),
-            )))
             .force_authoring(true)
             .role(sc_service::Role::Authority)
-            .build(dir)
+            .build(dir, node::chain_spec::dev_config().unwrap(),)
             .await
             .unwrap();
 


### PR DESCRIPTION
Closes #16
Closes #11 

This pr redesigns api around wiping and managing chain specs. It simplifies library and pushes directory management to the user. 

It would be better to take a look at tests and to `simple.rs` for a better idea.