### PR TITLE
Add farmer info

### DIFF
--- a/examples/complete.rs
+++ b/examples/complete.rs
@@ -44,7 +44,7 @@ async fn main() {
     farmer.start_farming().await;
 
     dbg!(node.get_info().await);
-    dbg!(farmer.get_info().await);
+    dbg!(farmer.get_info().await.unwrap());
 
     farmer.stop_farming().await;
     farmer.close().await;


### PR DESCRIPTION
Closes #9 

This pr adds a method for getting info for a farmer. It will return most of already known values like reward address, but also will return some introspection about all plots.