### PR TITLE
Update CI and add format check

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,7 +5,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  checks:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly-2022-08-12
+            components: rustfmt
+            override: true
+
+      - run: cargo fmt --all -- --check
+
+  clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -24,9 +37,44 @@ jobs:
             components: clippy
             override: true
 
+      - name: Configure cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "14.0"
+
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly-2022-08-12
+            components: clippy
+            override: true
+
+      - name: Configure cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - run: cargo test

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -38,12 +38,7 @@ jobs:
             override: true
 
       - name: Configure cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+        uses: Swatinem/rust-cache@v2
 
       - uses: actions-rs/clippy-check@v1
         with:
@@ -70,11 +65,6 @@ jobs:
             override: true
 
       - name: Configure cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+        uses: Swatinem/rust-cache@v2
 
       - run: cargo test


### PR DESCRIPTION
This pr:
- splits `cargo test` and `cargo clippy` into 2 jobs
- adds caching for those two
- adds formatting check

The first commit improves ci time for clippy from 14 mins to 11.
The second one improves from 11 mins to 10