### PR TITLE
serialize deserialize for public key

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ use subspace_core_primitives::PUBLIC_KEY_LENGTH;
     Serialize,
     Deserialize,
 )]
+#[serde(transparent)]
 pub struct PublicKey(pub subspace_core_primitives::PublicKey);
 
 impl From<[u8; PUBLIC_KEY_LENGTH]> for PublicKey {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,24 @@ pub use node::{chain_spec, Builder as NodeBuilder, Info as FarmerInfo, Mode as N
 pub use parse_ss58::Ss58ParsingError;
 
 use derive_more::{Deref, DerefMut};
+use serde::{Deserialize, Serialize};
 use subspace_core_primitives::PUBLIC_KEY_LENGTH;
 
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Deref, DerefMut)]
+#[derive(
+    Debug,
+    Default,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Deref,
+    DerefMut,
+    Serialize,
+    Deserialize,
+)]
 pub struct PublicKey(pub subspace_core_primitives::PublicKey);
 
 impl From<[u8; PUBLIC_KEY_LENGTH]> for PublicKey {


### PR DESCRIPTION
Very trivial and small one, did not want to bother you with DM's for this one @i1i1 

Note: I fixed `ByteSize` for serialization in the CLI, but the wrapper for `PublicKey` in SDK was not implementing `Serialize, Deserialize`, and in `subspace-core-primitives`, `PublicKey` was indeed deriving those, so it was a one-liner