### PR TITLE
Add some derives and add setting execution strategies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ jsonrpsee-core = "0.15.1"
 libp2p-core = "0.37"
 parity-db = "0.3"
 pin-project = "1"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 ss58-registry = "1.33"
 thiserror = "1"
 tokio-stream = { version = "0.1", features = ["sync", "time"] }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let node = Node::builder()
         .force_authoring(true)
-        .role(sc_service::Role::Authority)
+        .role(subspace_sdk::node::Role::Authority)
         .build("node", chain_spec::dev_config().unwrap())
         .await
         .unwrap();

--- a/examples/sync.rs
+++ b/examples/sync.rs
@@ -82,7 +82,7 @@ async fn main() -> anyhow::Result<()> {
                 .listen_on(vec!["/ip4/127.0.0.1/tcp/0".parse().unwrap()])
                 .force_authoring(true)
                 .force_synced(true)
-                .role(sc_service::Role::Authority)
+                .role(subspace_sdk::node::Role::Authority)
                 .build(node, chain_spec)
                 .await?;
 
@@ -105,7 +105,7 @@ async fn main() -> anyhow::Result<()> {
             let chain_spec = serde_json::from_str(&tokio::fs::read_to_string(spec).await?)?;
             let node = Node::builder()
                 .force_authoring(true)
-                .role(sc_service::Role::Authority)
+                .role(subspace_sdk::node::Role::Authority)
                 .boot_nodes(boot_nodes)
                 .build(node.as_ref(), chain_spec)
                 .await?;

--- a/src/farmer.rs
+++ b/src/farmer.rs
@@ -609,7 +609,7 @@ impl Farmer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::node::{chain_spec, Node};
+    use crate::node::{chain_spec, Node, Role};
     use tempdir::TempDir;
 
     #[tokio::test(flavor = "multi_thread")]
@@ -617,7 +617,7 @@ mod tests {
         let dir = TempDir::new("test").unwrap();
         let node = Node::builder()
             .force_authoring(true)
-            .role(sc_service::Role::Authority)
+            .role(Role::Authority)
             .build(dir.path(), chain_spec::dev_config().unwrap())
             .await
             .unwrap();
@@ -653,7 +653,7 @@ mod tests {
         let dir = TempDir::new("test").unwrap();
         let node = Node::builder()
             .force_authoring(true)
-            .role(sc_service::Role::Authority)
+            .role(Role::Authority)
             .build(dir.path(), chain_spec::dev_config().unwrap())
             .await
             .unwrap();
@@ -692,7 +692,7 @@ mod tests {
         let dir = TempDir::new("test").unwrap();
         let node = Node::builder()
             .force_authoring(true)
-            .role(sc_service::Role::Authority)
+            .role(Role::Authority)
             .build(dir.path(), chain_spec::dev_config().unwrap())
             .await
             .unwrap();
@@ -729,7 +729,7 @@ mod tests {
         let dir = TempDir::new("test").unwrap();
         let node = Node::builder()
             .force_authoring(true)
-            .role(sc_service::Role::Authority)
+            .role(Role::Authority)
             .build(dir.path(), chain_spec::dev_config().unwrap())
             .await
             .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ mod tests {
         let dir = TempDir::new("test").unwrap();
         let node = Node::builder()
             .force_authoring(true)
-            .role(sc_service::Role::Authority)
+            .role(node::Role::Authority)
             .build(dir, node::chain_spec::dev_config().unwrap())
             .await
             .unwrap();


### PR DESCRIPTION
This pr adds several things:
- serialize/deserialize derives for `Role` and `RpcMethods` for the node
- Add setter for execution strategies for node builder