### PR TITLE
Update monorepo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "core-payments-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -1199,9 +1199,12 @@ dependencies = [
  "log",
  "pallet-balances",
  "pallet-domain-registry",
+ "pallet-domain-tracker",
  "pallet-executor-registry",
+ "pallet-messenger",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-transporter",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
@@ -1210,6 +1213,7 @@ dependencies = [
  "sp-domains",
  "sp-inherents",
  "sp-io",
+ "sp-messenger",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
@@ -1717,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "domain-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1734,7 +1738,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4392,7 +4396,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4434,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4454,7 +4458,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4473,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4489,7 +4493,7 @@ dependencies = [
 [[package]]
 name = "pallet-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4506,7 +4510,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4522,7 +4526,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -4542,7 +4546,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4562,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4577,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4592,7 +4596,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4605,7 +4609,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4616,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4672,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4723,6 +4727,22 @@ dependencies = [
  "sp-api",
  "sp-runtime",
  "sp-weights",
+]
+
+[[package]]
+name = "pallet-transporter"
+version = "0.1.0"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-domains",
+ "sp-messenger",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -5828,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -5867,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -5908,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -5919,7 +5939,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "sc-client-api",
  "sc-consensus-subspace",
- "sc-piece-cache",
  "sc-rpc",
  "sc-utils",
  "sp-api",
@@ -5931,6 +5950,7 @@ dependencies = [
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-farmer-components",
+ "subspace-networking",
  "subspace-rpc-primitives",
 ]
 
@@ -6252,12 +6272,13 @@ dependencies = [
 [[package]]
 name = "sc-piece-cache"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "subspace-core-primitives",
  "subspace-networking",
+ "tracing",
 ]
 
 [[package]]
@@ -6442,7 +6463,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -7160,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "async-trait",
  "log",
@@ -7277,7 +7298,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7289,7 +7310,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7300,7 +7321,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -7324,7 +7345,7 @@ dependencies = [
 [[package]]
 name = "sp-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "parity-scale-codec",
  "sp-domains",
@@ -7429,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -7444,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -7874,7 +7895,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "blake2-rfc",
  "merkle_light",
@@ -7888,12 +7909,11 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "ark-bls12-381",
  "ark-ff",
  "ark-poly",
- "bitvec",
  "blake2-rfc",
  "derive_more",
  "dusk-bls12_381",
@@ -7916,12 +7936,11 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "anyhow",
  "async-trait",
  "base58",
- "bitvec",
  "blake2-rfc",
  "bytesize",
  "clap",
@@ -7964,13 +7983,11 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "async-trait",
- "bitvec",
  "blake2-rfc",
  "fs2",
- "hex",
  "libc",
  "parity-scale-codec",
  "rand 0.8.5",
@@ -7987,7 +8004,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -8005,7 +8022,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8038,17 +8055,19 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "hex",
  "serde",
  "subspace-core-primitives",
+ "subspace-farmer-components",
+ "subspace-networking",
 ]
 
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -8100,7 +8119,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -8172,7 +8191,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "derive_more",
  "domain-runtime-primitives",
@@ -8232,7 +8251,7 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "merlin 2.0.1",
  "schnorrkel",
@@ -8242,7 +8261,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -8259,7 +8278,7 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 
 [[package]]
 name = "substrate-bip39"
@@ -8378,7 +8397,7 @@ dependencies = [
 [[package]]
 name = "system-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "core-payments-domain-runtime",
  "domain-pallet-executive",
@@ -8395,6 +8414,7 @@ dependencies = [
  "pallet-messenger",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-transporter",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
@@ -8420,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "system-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=31bbee344ce5fd4dac5f04bfd1eb301158ffd24a#31bbee344ce5fd4dac5f04bfd1eb301158ffd24a"
+source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8140,6 +8140,7 @@ dependencies = [
  "blake2-rfc",
  "bytesize",
  "clap",
+ "core-payments-domain-runtime",
  "derive_more",
  "event-listener-primitives",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
 
 [[package]]
+name = "bytesize-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1a327ed2c8ba65a824d44aa6de5987c8cd785e1e37ba2b809e1b4b86932d64"
+dependencies = [
+ "bytesize",
+ "serde",
+]
+
+[[package]]
 name = "bytestring"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,7 +1199,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "core-payments-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -1721,7 +1731,7 @@ dependencies = [
 [[package]]
 name = "domain-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1738,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4396,7 +4406,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4438,7 +4448,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4458,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4477,7 +4487,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4493,7 +4503,7 @@ dependencies = [
 [[package]]
 name = "pallet-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4510,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4526,7 +4536,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -4546,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4566,7 +4576,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4581,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4596,7 +4606,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4609,7 +4619,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4620,7 +4630,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4676,7 +4686,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4732,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5848,7 +5858,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -5887,7 +5897,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -5928,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -6272,7 +6282,7 @@ dependencies = [
 [[package]]
 name = "sc-piece-cache"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6463,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -7181,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "async-trait",
  "log",
@@ -7298,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7310,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7321,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -7345,7 +7355,7 @@ dependencies = [
 [[package]]
 name = "sp-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "parity-scale-codec",
  "sp-domains",
@@ -7450,7 +7460,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -7465,7 +7475,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -7895,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "blake2-rfc",
  "merkle_light",
@@ -7909,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "ark-bls12-381",
  "ark-ff",
@@ -7936,7 +7946,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7983,7 +7993,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "async-trait",
  "blake2-rfc",
@@ -8004,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -8022,7 +8032,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8055,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "hex",
  "serde",
@@ -8067,7 +8077,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -8119,7 +8129,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -8139,6 +8149,7 @@ dependencies = [
  "base58",
  "blake2-rfc",
  "bytesize",
+ "bytesize-serde",
  "clap",
  "core-payments-domain-runtime",
  "derive_more",
@@ -8192,7 +8203,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "derive_more",
  "domain-runtime-primitives",
@@ -8252,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "merlin 2.0.1",
  "schnorrkel",
@@ -8262,7 +8273,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -8279,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 
 [[package]]
 name = "substrate-bip39"
@@ -8398,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "system-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "core-payments-domain-runtime",
  "domain-pallet-executive",
@@ -8441,7 +8452,7 @@ dependencies = [
 [[package]]
 name = "system-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=67007823b1a3cb994c3ba979b9dae741565593b2#67007823b1a3cb994c3ba979b9dae741565593b2"
+source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
 dependencies = [
  "parity-scale-codec",
  "sp-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,14 +41,15 @@ sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", re
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-version = { version = "5.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 
+core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
 sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
 sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
 sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
 sp-domains = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
 subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
 subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
 subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
 subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
 subspace-networking = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
 subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ libp2p-core = "0.37"
 parity-db = "0.4"
 pin-project = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 ss58-registry = "1.33"
 thiserror = "1"
 tokio-stream = { version = "0.1", features = ["sync", "time"] }
@@ -40,25 +41,24 @@ sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", re
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-version = { version = "5.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 
-sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-sp-domains = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
-system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "31bbee344ce5fd4dac5f04bfd1eb301158ffd24a" }
+sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+sp-domains = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
-serde_json = "1"
 tempfile = "3.3"
 tokio = { version = "1.21", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = "0.1"
 base58 = "0.2"
 blake2-rfc = "0.2"
 bytesize = "1.1"
+bytesize-serde = "0.2"
 derive_more = "0.99"
 event-listener-primitives = "2.0.1"
 futures = "0.3"
@@ -41,22 +42,22 @@ sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", re
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-version = { version = "5.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 
-core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-sp-domains = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
-system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "67007823b1a3cb994c3ba979b9dae741565593b2" }
+core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+sp-domains = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/examples/complete.rs
+++ b/examples/complete.rs
@@ -1,6 +1,8 @@
 use bytesize::ByteSize;
 use futures::StreamExt;
-use subspace_sdk::{chain_spec, Farmer, Node, PlotDescription, PublicKey};
+use subspace_sdk::{
+    chain_spec, farmer::CacheDescription, Farmer, Node, PlotDescription, PublicKey,
+};
 
 #[tokio::main]
 async fn main() {
@@ -19,7 +21,12 @@ async fn main() {
     let farmer: Farmer = Farmer::builder()
         // .ws_rpc("127.0.0.1:9955".parse().unwrap())
         // .listen_on("/ip4/0.0.0.0/tcp/40333".parse().unwrap())
-        .build(reward_address, node.clone(), &plots)
+        .build(
+            reward_address,
+            node.clone(),
+            &plots,
+            CacheDescription::new("cache", ByteSize::mib(100)).unwrap(),
+        )
         .await
         .expect("Failed to init a farmer");
 
@@ -66,6 +73,7 @@ async fn main() {
             reward_address,
             node.clone(),
             &[PlotDescription::new("plot", ByteSize::gb(10))],
+            CacheDescription::new("cache", ByteSize::mib(100)).unwrap(),
         )
         .await
         .expect("Failed to init a farmer");

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,7 @@
 use bytesize::ByteSize;
-use subspace_sdk::{chain_spec, Farmer, Node, PlotDescription, PublicKey};
+use subspace_sdk::{
+    chain_spec, farmer::CacheDescription, Farmer, Node, PlotDescription, PublicKey,
+};
 
 #[tokio::main]
 async fn main() {
@@ -15,7 +17,12 @@ async fn main() {
     let plots = [PlotDescription::new("plot", ByteSize::mb(100))];
     let farmer: Farmer = Farmer::builder()
         .listen_on(vec!["/ip4/0.0.0.0/tcp/40333".parse().unwrap()])
-        .build(PublicKey::from([13; 32]), node.clone(), &plots)
+        .build(
+            PublicKey::from([13; 32]),
+            node.clone(),
+            &plots,
+            CacheDescription::new("cache", ByteSize::mib(100)).unwrap(),
+        )
         .await
         .expect("Failed to init a farmer");
 

--- a/src/farmer.rs
+++ b/src/farmer.rs
@@ -4,6 +4,7 @@ use anyhow::Context;
 use bytesize::ByteSize;
 use futures::{prelude::*, stream::FuturesUnordered};
 use libp2p_core::Multiaddr;
+use serde::{Deserialize, Serialize};
 use subspace_core_primitives::{PieceIndexHash, SectorIndex, PLOT_SECTOR_SIZE};
 use subspace_farmer::single_disk_plot::{
     piece_reader::PieceReader, SingleDiskPlot, SingleDiskPlotError, SingleDiskPlotId,
@@ -17,12 +18,13 @@ use tokio::sync::{oneshot, watch, Mutex};
 use crate::{Node, PublicKey};
 
 /// Description of the cache
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CacheDescription {
-    /// Path of the plot
+    /// Path to the cache description
     pub directory: PathBuf,
     /// Space which you want to pledge
+    #[serde(with = "bytesize_serde")]
     pub space_pledged: ByteSize,
 }
 

--- a/src/farmer.rs
+++ b/src/farmer.rs
@@ -23,9 +23,9 @@ use crate::{Node, PublicKey};
 pub struct CacheDescription {
     /// Path to the cache description
     pub directory: PathBuf,
-    /// Space which you want to pledge
+    /// Space which you want to dedicate
     #[serde(with = "bytesize_serde")]
-    pub space_pledged: ByteSize,
+    pub space_dedicated: ByteSize,
 }
 
 const MIN_CACHE_SIZE: ByteSize = ByteSize::mib(1);
@@ -39,14 +39,14 @@ impl CacheDescription {
     /// Construct Plot description
     pub fn new(
         directory: impl Into<PathBuf>,
-        space_pledged: ByteSize,
+        space_dedicated: ByteSize,
     ) -> Result<Self, CacheTooSmall> {
-        if space_pledged < MIN_CACHE_SIZE {
+        if space_dedicated < MIN_CACHE_SIZE {
             return Err(CacheTooSmall);
         }
         Ok(Self {
             directory: directory.into(),
-            space_pledged,
+            space_dedicated,
         })
     }
 
@@ -259,7 +259,7 @@ impl Builder {
             cache.directory,
             listen_on,
             bootstrap_nodes,
-            NonZeroUsize::new(cache.space_pledged.as_u64() as usize)
+            NonZeroUsize::new(cache.space_dedicated.as_u64() as usize)
                 .expect("Always more than 1Mib"),
             &Arc::new(std::sync::Mutex::new(None)),
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,7 @@ mod tests {
     use subspace_farmer::RpcClient;
     use tempfile::TempDir;
 
+    use super::farmer::CacheDescription;
     use super::*;
 
     #[tokio::test(flavor = "multi_thread")]
@@ -180,13 +181,18 @@ mod tests {
 
         let mut slot_info_sub = node.subscribe_slot_info().await.unwrap();
 
-        let dir = TempDir::new().unwrap();
+        let (dir, cache_dir) = (TempDir::new().unwrap(), TempDir::new().unwrap());
         let plot_descriptions = [PlotDescription::new(
             dir.path(),
             bytesize::ByteSize::mib(32),
         )];
         let _farmer = Farmer::builder()
-            .build(Default::default(), node.clone(), &plot_descriptions)
+            .build(
+                Default::default(),
+                node.clone(),
+                &plot_descriptions,
+                CacheDescription::new(cache_dir.as_ref(), bytesize::ByteSize::mib(32)).unwrap(),
+            )
             .await
             .unwrap();
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -250,10 +250,15 @@ impl Builder {
                 .transpose()
                 .context("Failed to decode DSN bootsrap nodes")?
                 .unwrap_or_default();
+            let listen_on = if dsn_listen_on.is_empty() {
+                vec!["/ip4/0.0.0.0/tcp/0".parse().expect("Always valid")]
+            } else {
+                dsn_listen_on
+            };
 
             subspace_service::DsnConfig {
                 bootstrap_nodes,
-                listen_on: dsn_listen_on,
+                listen_on,
                 keypair,
             }
         };


### PR DESCRIPTION
This pr adds some options and updates monorepo to support all the additions. Also it adds gemini 3a chainspec.

There are still some todo, for example support of running domain system (which as far as I remember should be disabled for gemini 3a).