### PR TITLE
Update monorepo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "core-payments-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -1797,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "domain-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1814,7 +1814,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4478,7 +4478,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4520,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4540,7 +4540,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4559,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4575,7 +4575,7 @@ dependencies = [
 [[package]]
 name = "pallet-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4592,7 +4592,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4608,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -4628,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4648,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4663,7 +4663,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4691,7 +4691,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4702,7 +4702,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4814,7 +4814,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5930,7 +5930,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -5969,7 +5969,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -6010,7 +6010,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -6354,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "sc-piece-cache"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -7263,7 +7263,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "async-trait",
  "log",
@@ -7380,7 +7380,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7392,7 +7392,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7403,7 +7403,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -7427,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "sp-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "parity-scale-codec",
  "sp-domains",
@@ -7532,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -7547,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -7977,9 +7977,8 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
- "blake2-rfc",
  "merkle_light",
  "parity-scale-codec",
  "reed-solomon-erasure",
@@ -7991,12 +7990,12 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "ark-bls12-381",
  "ark-ff",
  "ark-poly",
- "blake2-rfc",
+ "blake2",
  "derive_more",
  "dusk-bls12_381",
  "dusk-bytes",
@@ -8018,12 +8017,11 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "anyhow",
  "async-trait",
  "base58",
- "blake2-rfc",
  "bytesize",
  "clap",
  "derive_more",
@@ -8065,10 +8063,9 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "async-trait",
- "blake2-rfc",
  "fs2",
  "libc",
  "parity-scale-codec",
@@ -8086,7 +8083,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -8104,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8137,7 +8134,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "hex",
  "serde",
@@ -8149,7 +8146,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -8201,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -8277,7 +8274,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "derive_more",
  "domain-runtime-primitives",
@@ -8337,7 +8334,7 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "merlin 2.0.1",
  "schnorrkel",
@@ -8347,7 +8344,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -8364,7 +8361,7 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 
 [[package]]
 name = "substrate-bip39"
@@ -8483,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "system-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "core-payments-domain-runtime",
  "domain-pallet-executive",
@@ -8526,7 +8523,7 @@ dependencies = [
 [[package]]
 name = "system-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3cfeea5b586419e1e7b114ad4502901b6a527572#3cfeea5b586419e1e7b114ad4502901b6a527572"
+source = "git+https://github.com/subspace/subspace?rev=3a864231f140e144561826d0145561f3539ba6d7#3a864231f140e144561826d0145561f3539ba6d7"
 dependencies = [
  "parity-scale-codec",
  "sp-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,22 +44,22 @@ sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", re
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-version = { version = "5.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 
-core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-sp-domains = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
-system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "3cfeea5b586419e1e7b114ad4502901b6a527572" }
+core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+sp-domains = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
+system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "3a864231f140e144561826d0145561f3539ba6d7" }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
This pr updates monorepo to the [chainspec release version](https://github.com/subspace/subspace/releases/tag/chain-spec-gemini-3a-2022-nov-28).