### PR TITLE
Update monorepo and fix syncing bug. Add example with gemini 3a

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,7 +1185,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "core-payments-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "domain-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1800,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4506,7 +4506,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4548,7 +4548,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4587,7 +4587,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "pallet-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4620,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -4656,7 +4656,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4676,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4691,7 +4691,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4706,7 +4706,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4730,7 +4730,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5958,7 +5958,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -5997,7 +5997,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -6038,7 +6038,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -6382,7 +6382,7 @@ dependencies = [
 [[package]]
 name = "sc-piece-cache"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6573,7 +6573,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -7291,7 +7291,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "async-trait",
  "log",
@@ -7408,7 +7408,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7420,7 +7420,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7431,7 +7431,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "sp-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "parity-scale-codec",
  "sp-domains",
@@ -7560,7 +7560,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -7575,7 +7575,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -8005,7 +8005,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "merkle_light",
  "parity-scale-codec",
@@ -8018,7 +8018,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "ark-bls12-381",
  "ark-ff",
@@ -8046,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8094,7 +8094,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "async-trait",
  "fs2",
@@ -8114,7 +8114,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -8132,7 +8132,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -8165,7 +8165,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "hex",
  "serde",
@@ -8177,7 +8177,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -8229,7 +8229,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -8246,6 +8246,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backoff",
  "base58",
  "blake2",
  "bytesize",
@@ -8306,7 +8307,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "derive_more",
  "domain-runtime-primitives",
@@ -8366,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "merlin 2.0.1",
  "schnorrkel",
@@ -8376,7 +8377,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -8393,7 +8394,7 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 
 [[package]]
 name = "substrate-bip39"
@@ -8512,7 +8513,7 @@ dependencies = [
 [[package]]
 name = "system-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "core-payments-domain-runtime",
  "domain-pallet-executive",
@@ -8555,7 +8556,7 @@ dependencies = [
 [[package]]
 name = "system-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=7a6411ae36df71e1a6f3569f65f6372b83e8ce24#7a6411ae36df71e1a6f3569f65f6372b83e8ce24"
+source = "git+https://github.com/subspace/subspace?rev=4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33#4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33"
 dependencies = [
  "parity-scale-codec",
  "sp-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
+backoff = "0.4"
 base58 = "0.2"
 blake2 = "0.10.5"
 bytesize = "1.1"
@@ -45,22 +46,22 @@ sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", re
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-version = { version = "5.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 
-core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-sp-domains = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
-system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "7a6411ae36df71e1a6f3569f65f6372b83e8ce24" }
+core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+sp-domains = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
+system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "4fd23d29f32d62471cd99e8ed5c9d7fd5f009b33" }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/examples/complete.rs
+++ b/examples/complete.rs
@@ -15,7 +15,7 @@ async fn main() {
         .await
         .expect("Failed to init a node");
 
-    node.sync().await;
+    node.sync().await.unwrap();
 
     let reward_address = PublicKey::from([0; 32]);
     let plots = [PlotDescription::new("plot", ByteSize::gb(10))];
@@ -67,7 +67,7 @@ async fn main() {
         .build("node", chain_spec::dev_config().unwrap())
         .await
         .expect("Failed to init a node");
-    node.sync().await;
+    node.sync().await.unwrap();
 
     let farmer = Farmer::builder()
         .build(

--- a/examples/gemini-3a.rs
+++ b/examples/gemini-3a.rs
@@ -1,0 +1,53 @@
+use futures::stream::StreamExt;
+
+use subspace_sdk::node::{self, Node};
+use tempfile::TempDir;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("runtime::subspace::executor=off".parse().unwrap())
+                .add_directive("info".parse().unwrap()),
+        )
+        .init();
+
+    let node_dir = TempDir::new()?;
+    let node = Node::builder()
+        .role(node::Role::Authority)
+        .network(
+            node::NetworkBuilder::new()
+                .listen_addresses(vec![
+                    "/ip6/::/tcp/30333".parse().unwrap(),
+                    "/ip4/0.0.0.0/tcp/30333".parse().unwrap(),
+                ])
+                .enable_mdns(true),
+        )
+        .rpc(
+            node::RpcBuilder::new()
+                .http("127.0.0.1:9933".parse().unwrap())
+                .ws("127.0.0.1:9944".parse().unwrap())
+                .cors(vec![
+                    "http://localhost:*".to_owned(),
+                    "http://127.0.0.1:*".to_owned(),
+                    "https://localhost:*".to_owned(),
+                    "https://127.0.0.1:*".to_owned(),
+                    "https://polkadot.js.org".to_owned(),
+                ]),
+        )
+        .dsn(node::DsnBuilder::new().listen_addresses(vec![
+            "/ip6/::/tcp/30433".parse().unwrap(),
+            "/ip4/0.0.0.0/tcp/30433".parse().unwrap(),
+        ]))
+        .execution_strategy(node::ExecutionStrategy::AlwaysWasm)
+        .offchain_worker(node::OffchainWorkerBuilder::new().enabled(true))
+        .build(node_dir.as_ref(), node::chain_spec::gemini_3a().unwrap())
+        .await?;
+
+    node.sync().await?;
+    tracing::info!("Node was synced!");
+
+    node.close().await;
+    Ok(())
+}

--- a/examples/sync.rs
+++ b/examples/sync.rs
@@ -109,7 +109,7 @@ async fn main() -> anyhow::Result<()> {
                 .build(node.as_ref(), chain_spec)
                 .await?;
 
-            node.sync().await;
+            node.sync().await.unwrap();
             tracing::info!("Node was synced!");
 
             node.subscribe_new_blocks()

--- a/src/farmer.rs
+++ b/src/farmer.rs
@@ -120,13 +120,12 @@ impl PlotDescription {
 
 mod builder {
     use crate::generate_builder;
-    use derivative::Derivative;
     use derive_builder::Builder;
     use libp2p_core::Multiaddr;
     use serde::{Deserialize, Serialize};
 
     /// Technical type which stores all
-    #[derive(Debug, Clone, Derivative, Builder, Serialize, Deserialize)]
+    #[derive(Debug, Clone, Default, Builder, Serialize, Deserialize)]
     #[builder(pattern = "immutable", build_fn(name = "_build"), name = "Builder")]
     #[non_exhaustive]
     pub struct Config {
@@ -136,7 +135,7 @@ mod builder {
     }
 
     /// Farmer DSN
-    #[derive(Debug, Clone, Default, Derivative, Builder, Serialize, Deserialize)]
+    #[derive(Debug, Clone, Default, Builder, Serialize, Deserialize)]
     #[builder(pattern = "owned", build_fn(name = "_build"), name = "DsnBuilder")]
     #[non_exhaustive]
     pub struct Dsn {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -900,11 +900,11 @@ impl Node {
                             (Arc::clone(&best_number), &network, &client);
                         async move {
                             let new_best_number = client.chain_info().best_number;
-                            let imported_blocks = best_number
+                            let not_imported_blocks = best_number
                                 .swap(new_best_number, std::sync::atomic::Ordering::Relaxed)
                                 == new_best_number;
                             match network.status().await?.sync_state {
-                                SyncState::Idle if imported_blocks => {
+                                SyncState::Idle if not_imported_blocks => {
                                     Err(backoff::Error::transient(()))
                                 }
                                 SyncState::Idle => Ok(SyncStatus::Importing {


### PR DESCRIPTION
This pr:
- Changes syncing logic
- updates monorepo
- adds example with configuration for node for gemini 3a
- adds extra configuration for network
- adds configuration for offchain workers