### PR TITLE
Improve syncing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ ss58-registry = "1.33"
 thiserror = "1"
 tokio = { version = "1.21", features = ["fs", "rt"] }
 tokio-stream = { version = "0.1", features = ["sync", "time"] }
+tracing = "0.1"
 
 frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
@@ -67,7 +68,6 @@ system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "5
 clap = { version = "4", features = ["derive"] }
 tempfile = "3.3"
 tokio = { version = "1.21", features = ["rt-multi-thread", "macros"] }
-tracing = "0.1"
 tracing-subscriber = "0.3"
 
 [patch.crates-io]


### PR DESCRIPTION
This pr show less syncing false negatives during syncing, by relying on substrate syncing more. Ideally we should return at the very first `Idle` sync status, but sometimes networking returns false positives here. So this is still a hack.