### PR TITLE
Update monorepo and fix farmer dsn bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "core-payments-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -1362,6 +1362,7 @@ dependencies = [
  "pallet-domain-tracker",
  "pallet-executor-registry",
  "pallet-messenger",
+ "pallet-sudo",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-transporter",
@@ -1789,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "data-encoding-macro"
@@ -1815,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -2058,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "domain-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2075,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2395,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3194,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
@@ -3428,9 +3429,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "is-terminal"
@@ -3440,7 +3441,7 @@ checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes 1.0.3",
- "rustix 0.36.4",
+ "rustix 0.36.5",
  "windows-sys 0.42.0",
 ]
 
@@ -4762,7 +4763,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
 dependencies = [
- "rustix 0.36.4",
+ "rustix 0.36.5",
 ]
 
 [[package]]
@@ -5299,7 +5300,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5363,7 +5364,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5383,7 +5384,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5402,7 +5403,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5418,7 +5419,7 @@ dependencies = [
 [[package]]
 name = "pallet-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5435,7 +5436,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5451,7 +5452,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -5471,7 +5472,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5491,7 +5492,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5506,7 +5507,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5521,7 +5522,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5534,7 +5535,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5545,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5601,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5657,7 +5658,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6146,9 +6147,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
+checksum = "276470f7f281b0ed53d2ae42dd52b4a8d08853a3c70e7fe95882acbb98a6ae94"
 dependencies = [
  "bytes",
  "heck",
@@ -6242,9 +6243,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57098b1a3d2159d13dc3a98c0e3a5f8ab91ac3dd2471e52b1d712ea0c1085555"
+checksum = "72ef4ced82a24bb281af338b9e8f94429b6eca01b4e66d899f40031f074e74c9"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -6372,11 +6373,10 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -6658,9 +6658,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
@@ -6915,7 +6915,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6954,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -6995,7 +6995,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -7337,18 +7337,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-piece-cache"
-version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
-dependencies = [
- "parity-scale-codec",
- "sc-client-api",
- "subspace-core-primitives",
- "subspace-networking",
- "tracing",
-]
-
-[[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
 source = "git+https://github.com/subspace/substrate?rev=6d57dbc639bb3d9460dabeccb063cc6556452535#6d57dbc639bb3d9460dabeccb063cc6556452535"
@@ -7530,7 +7518,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -7675,9 +7663,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d8a765117b237ef233705cc2cc4c6a27fccd46eea6ef0c8c6dae5f3ef407f8"
+checksum = "001cf62ece89779fd16105b5f515ad0e5cedcd5440d3dd806bb067978e7c3608"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -7689,9 +7677,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcd47b380d8c4541044e341dcd9475f55ba37ddc50c908d945fc036a8642496"
+checksum = "303959cf613a6f6efd19ed4b4ad5bf79966a13352716299ad532cfb115f4205c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7787,9 +7775,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
+checksum = "d9512ffd81e3a3503ed401f79c33168b9148c75038956039166cd750eaa037c3"
 dependencies = [
  "secp256k1-sys",
 ]
@@ -7885,9 +7873,9 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
 dependencies = [
  "serde_derive",
 ]
@@ -7912,9 +7900,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8270,7 +8258,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "async-trait",
  "log",
@@ -8387,7 +8375,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8399,7 +8387,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8410,7 +8398,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -8434,7 +8422,7 @@ dependencies = [
 [[package]]
 name = "sp-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "parity-scale-codec",
  "sp-domains",
@@ -8539,7 +8527,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -8554,7 +8542,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -8881,9 +8869,9 @@ dependencies = [
 
 [[package]]
 name = "ss58-registry"
-version = "1.35.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0813c10b9dbdc842c2305f949f724c64866e4ef4d09c9151e96f6a2106773c"
+checksum = "23d92659e7d18d82b803824a9ba5a6022cff101c3491d027c1c1d8d30e749284"
 dependencies = [
  "Inflector",
  "num-format",
@@ -9003,7 +8991,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "merkle_light",
  "parity-scale-codec",
@@ -9016,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "ark-bls12-381",
  "ark-ff",
@@ -9044,7 +9032,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9092,7 +9080,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "async-trait",
  "fs2",
@@ -9114,7 +9102,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -9132,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -9165,7 +9153,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "hex",
  "serde",
@@ -9177,7 +9165,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -9229,7 +9217,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -9256,6 +9244,7 @@ dependencies = [
  "derivative",
  "derive_builder 0.12.0",
  "derive_more",
+ "domain-runtime-primitives",
  "event-listener-primitives",
  "frame-support",
  "futures",
@@ -9307,8 +9296,9 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
+ "backoff",
  "derive_more",
  "domain-runtime-primitives",
  "frame-support",
@@ -9329,7 +9319,6 @@ dependencies = [
  "sc-consensus-subspace-rpc",
  "sc-executor",
  "sc-network",
- "sc-piece-cache",
  "sc-rpc",
  "sc-rpc-api",
  "sc-rpc-spec-v2",
@@ -9354,6 +9343,7 @@ dependencies = [
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
+ "subspace-archiving",
  "subspace-core-primitives",
  "subspace-fraud-proof",
  "subspace-networking",
@@ -9361,13 +9351,14 @@ dependencies = [
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "merlin 2.0.1",
  "schnorrkel",
@@ -9377,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -9394,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 
 [[package]]
 name = "substrate-bip39"
@@ -9522,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "system-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "core-payments-domain-runtime",
  "domain-pallet-executive",
@@ -9537,6 +9528,7 @@ dependencies = [
  "pallet-domain-tracker",
  "pallet-executor-registry",
  "pallet-messenger",
+ "pallet-sudo",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-transporter",
@@ -9565,7 +9557,7 @@ dependencies = [
 [[package]]
 name = "system-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=504a798f4f6dc3fc87aa7787e9a1e9fb234df97a#504a798f4f6dc3fc87aa7787e9a1e9fb234df97a"
+source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9738,9 +9730,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg",
  "bytes",
@@ -9753,7 +9745,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -10624,9 +10616,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki 0.22.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "core-payments-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "domain-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3783,7 +3783,7 @@ dependencies = [
  "libp2p-kad 0.41.0",
  "libp2p-mdns 0.41.0",
  "libp2p-metrics 0.10.0",
- "libp2p-mplex 0.37.0",
+ "libp2p-mplex",
  "libp2p-noise 0.40.0",
  "libp2p-ping 0.40.1",
  "libp2p-request-response 0.22.1",
@@ -3816,7 +3816,6 @@ dependencies = [
  "libp2p-kad 0.42.0",
  "libp2p-mdns 0.42.0",
  "libp2p-metrics 0.11.0",
- "libp2p-mplex 0.38.0",
  "libp2p-noise 0.41.0",
  "libp2p-ping 0.41.0",
  "libp2p-quic",
@@ -4131,23 +4130,6 @@ dependencies = [
  "bytes",
  "futures",
  "libp2p-core 0.37.0",
- "log",
- "nohash-hasher",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "smallvec",
- "unsigned-varint",
-]
-
-[[package]]
-name = "libp2p-mplex"
-version = "0.38.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "futures",
- "libp2p-core 0.38.0",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
@@ -5266,9 +5248,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4bda43fd1b844cbc6e6e54b5444e2b1bc7838bce59ad205902cccbb26d6761"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
 dependencies = [
  "asn1-rs 0.5.1",
 ]
@@ -5300,7 +5282,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5364,7 +5346,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5384,7 +5366,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5403,7 +5385,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5419,7 +5401,7 @@ dependencies = [
 [[package]]
 name = "pallet-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5436,7 +5418,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5452,7 +5434,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -5472,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5492,7 +5474,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5507,7 +5489,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5522,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5535,7 +5517,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5546,7 +5528,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5602,7 +5584,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5658,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6915,7 +6897,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6954,7 +6936,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -6995,7 +6977,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -7518,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -8258,7 +8240,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "async-trait",
  "log",
@@ -8375,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8387,7 +8369,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-tracker"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8398,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -8422,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "sp-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "parity-scale-codec",
  "sp-domains",
@@ -8527,7 +8509,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -8542,7 +8524,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -8991,7 +8973,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "merkle_light",
  "parity-scale-codec",
@@ -9004,7 +8986,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "ark-bls12-381",
  "ark-ff",
@@ -9032,7 +9014,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9080,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "async-trait",
  "fs2",
@@ -9102,7 +9084,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -9120,7 +9102,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -9153,7 +9135,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "hex",
  "serde",
@@ -9165,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -9217,7 +9199,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -9296,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "backoff",
  "derive_more",
@@ -9358,7 +9340,7 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "merlin 2.0.1",
  "schnorrkel",
@@ -9368,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -9385,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 
 [[package]]
 name = "substrate-bip39"
@@ -9513,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "system-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "core-payments-domain-runtime",
  "domain-pallet-executive",
@@ -9557,7 +9539,7 @@ dependencies = [
 [[package]]
 name = "system-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=151c559af79231581cd8fc95067c76d10cd12cab#151c559af79231581cd8fc95067c76d10cd12cab"
+source = "git+https://github.com/subspace/subspace?rev=b2bd81bf845fa0b9fc8f01da8184a4b17d7162df#b2bd81bf845fa0b9fc8f01da8184a4b17d7162df"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10698,7 +10680,7 @@ dependencies = [
  "hkdf",
  "hmac 0.10.1",
  "log",
- "oid-registry 0.6.0",
+ "oid-registry 0.6.1",
  "p256",
  "p384",
  "rand 0.8.5",
@@ -11106,7 +11088,7 @@ dependencies = [
  "der-parser 8.1.0",
  "lazy_static",
  "nom",
- "oid-registry 0.6.0",
+ "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
  "time 0.3.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,23 +47,23 @@ sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", re
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-version = { version = "5.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 
-core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-domain-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-sp-domains = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
-system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+domain-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+sp-domains = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
+system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "b2bd81bf845fa0b9fc8f01da8184a4b17d7162df" }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,22 +47,23 @@ sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", re
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-version = { version = "5.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 
-core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-sp-domains = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
-system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "504a798f4f6dc3fc87aa7787e9a1e9fb234df97a" }
+core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+domain-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+sp-domains = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
+system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "151c559af79231581cd8fc95067c76d10cd12cab" }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/src/farmer.rs
+++ b/src/farmer.rs
@@ -353,6 +353,10 @@ impl Config {
         let mut single_disk_plots = Vec::with_capacity(plots.len());
         let mut plot_info = HashMap::with_capacity(plots.len());
         let (dsn_node, mut dsn_node_runner) = dsn.configure_dsn(cache).await?;
+        let piece_publisher_semaphore =
+            Arc::new(tokio::sync::Semaphore::new(piece_receiver_batch_size));
+        let piece_receiver_semaphore =
+            Arc::new(tokio::sync::Semaphore::new(piece_publisher_batch_size));
 
         for description in plots {
             let directory = description.directory.clone();
@@ -363,8 +367,8 @@ impl Config {
                 reward_address: *reward_address,
                 rpc_client: node.clone(),
                 dsn_node: dsn_node.clone(),
-                piece_receiver_batch_size,
-                piece_publisher_batch_size,
+                piece_receiver_semaphore: Arc::clone(&piece_receiver_semaphore),
+                piece_publisher_semaphore: Arc::clone(&piece_publisher_semaphore),
             };
             let single_disk_plot = SingleDiskPlot::new(description)?;
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -363,6 +363,10 @@ mod builder {
         vec!["/ip4/127.0.0.1/tcp/0".parse().expect("Always valid")]
     }
 
+    fn default_piece_publisher_batch_size() -> usize {
+        15
+    }
+
     /// Node DSN builder
     #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize)]
     #[derivative(Default)]
@@ -386,6 +390,11 @@ mod builder {
         #[builder(default)]
         #[serde(default)]
         pub allow_non_global_addresses_in_dht: bool,
+        /// Sets piece publisher batch size
+        #[builder(default = "default_piece_publisher_batch_size()")]
+        #[derivative(Default(value = "default_piece_publisher_batch_size()"))]
+        #[serde(default = "default_piece_publisher_batch_size")]
+        pub piece_publisher_batch_size: usize,
     }
 
     /// Offchain worker config
@@ -590,6 +599,7 @@ impl Config {
                 boot_nodes,
                 reserved_nodes,
                 allow_non_global_addresses_in_dht,
+                piece_publisher_batch_size,
             } = dsn;
             let keypair = {
                 let keypair = network
@@ -643,6 +653,7 @@ impl Config {
                 reserved_peers: reserved_nodes,
                 listen_on,
                 keypair,
+                piece_publisher_batch_size,
             }
         };
 
@@ -697,18 +708,21 @@ impl Config {
                 runtime_cache_size: 2,
             },
             force_new_slot_notifications: false,
-            dsn_config,
-            piece_cache_size: piece_cache_size.as_u64(),
+            subspace_networking: subspace_service::SubspaceNetworking::Create {
+                config: dsn_config,
+                piece_cache_size: piece_cache_size.as_u64(),
+            },
         };
 
+        let partial_components =
+            subspace_service::new_partial::<RuntimeApi, ExecutorDispatch>(&configuration)
+                .context("Failed to build a partial subspace node")?;
+
         let slot_proportion = sc_consensus_slots::SlotProportion::new(2f32 / 3f32);
-        let full_client = subspace_service::new_full::<RuntimeApi, ExecutorDispatch>(
-            configuration,
-            true,
-            slot_proportion,
-        )
-        .await
-        .context("Failed to build a full subspace node")?;
+        let full_client =
+            subspace_service::new_full(configuration, partial_components, true, slot_proportion)
+                .await
+                .context("Failed to build a full subspace node")?;
 
         let subspace_service::NewFull {
             mut task_manager,

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -925,10 +925,7 @@ impl Node {
                         network
                             .status()
                             .map(|result_status| match result_status?.sync_state {
-                                SyncState::Idle => {
-                                    tracing::error!("Idle");
-                                    Err(backoff::Error::transient(()))
-                                }
+                                SyncState::Idle => Err(backoff::Error::transient(())),
                                 SyncState::Importing { target } => {
                                     Ok(SyncStatus::Importing { target })
                                 }


### PR DESCRIPTION
This pr updates monorepo adding some its new features. Also, it fixes the following bug: beforehand we didn't serve piece by hash requests at all in the cli, so farmers didn't respond with any pieces if they were requested.