### PR TITLE
Remove false positive logging warnings

### DIFF
--- a/src/networking.rs
+++ b/src/networking.rs
@@ -135,12 +135,7 @@ impl<S: subspace_networking::RecordStorage> subspace_networking::RecordStorage
         &mut self,
         r: subspace_networking::libp2p::kad::Record,
     ) -> subspace_networking::libp2p::kad::store::Result<()> {
-        self.inner
-            .lock()
-            .unwrap()
-            .as_mut()
-            .map(|x| x.put(r))
-            .unwrap_or(Err(subspace_networking::libp2p::kad::store::Error::MaxRecords))
+        self.inner.lock().unwrap().as_mut().map(|x| x.put(r)).unwrap_or(Ok(()))
     }
 
     fn remove(&mut self, k: &subspace_networking::libp2p::kad::record::Key) {


### PR DESCRIPTION
During syncing if I synced 300-400 blocks I started to see those warnings in logs
```
2022-12-15T11:24:14.182520Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:14.304436Z  INFO substrate: ⚙  Syncing  2.4 bps, target=#142813 (51 peers), best: #92026 (0xb228…488e), finalized #91926 (0xbd5f…be7b), ⬇ 35.2kiB/s ⬆ 1.2kiB/s
2022-12-15T11:24:14.401207Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:14.792447Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:15.033881Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:15.327172Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:15.586472Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:15.732646Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:15.839591Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:16.610699Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:17.142361Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:17.964498Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:18.100674Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:18.189812Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
2022-12-15T11:24:18.417453Z  WARN subspace_networking::node_runner: Failed to put value. err=MaxRecords
```

This pr fixes those warnings