### PR TITLE
Fallback to substrate syncing mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9216,7 +9216,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "backoff",
  "base58",
  "blake2",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-backoff = "0.4"
 base58 = "0.2"
 blake2 = "0.10.5"
 bytesize = "1.1"


### PR DESCRIPTION
This pr uses substrate syncing mechanism. It also returns error if we failed to fetch status at some moment of time (so we assume that error handling is done on sdk client side). Run it for 11 minutes and didn't get any error.

In the future, we can return some specific error if we went offline.