### PR TITLE
Migrate to handmade rpc wrapper and reuse jsonrpsee traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8991,6 +8991,7 @@ dependencies = [
  "sc-executor",
  "sc-network",
  "sc-network-common",
+ "sc-rpc-api",
  "sc-service",
  "sc-state-db",
  "sc-subspace-chain-specs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/subs
 sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
 sc-network-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809", default-features = false }
 sc-state-db = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod farmer;
 pub(crate) mod networking;
 /// Module related to the node
 pub mod node;
+pub(crate) mod utils;
 
 use derive_more::{Deref, DerefMut};
 pub use farmer::{Builder as FarmerBuilder, Farmer, Info as NodeInfo, Plot, PlotDescription};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use futures::prelude::*;
+use jsonrpsee_core::client::{
+    BatchResponse, ClientT, Subscription, SubscriptionClientT, SubscriptionKind,
+};
+use jsonrpsee_core::params::BatchRequestBuilder;
+use jsonrpsee_core::server::rpc_module::RpcModule;
+use jsonrpsee_core::traits::ToRpcParams;
+use jsonrpsee_core::Error;
+use serde::de::DeserializeOwned;
+
+#[derive(Clone, Debug)]
+pub(crate) struct Rpc {
+    inner: Arc<RpcModule<()>>,
+}
+
+impl Rpc {
+    pub fn new(handlers: &sc_service::RpcHandlers) -> Self {
+        let inner = handlers.handle();
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl ClientT for Rpc {
+    async fn notification<Params>(&self, method: &str, params: Params) -> Result<(), Error>
+    where
+        Params: ToRpcParams + Send,
+    {
+        self.inner.call(method, params).await
+    }
+
+    async fn request<R, Params>(&self, method: &str, params: Params) -> Result<R, Error>
+    where
+        R: DeserializeOwned,
+        Params: ToRpcParams + Send,
+    {
+        self.inner.call(method, params).await
+    }
+
+    async fn batch_request<'a, R>(
+        &self,
+        _batch: BatchRequestBuilder<'a>,
+    ) -> Result<BatchResponse<'a, R>, Error>
+    where
+        R: DeserializeOwned + std::fmt::Debug + 'a,
+    {
+        unreachable!("It isn't called at all")
+    }
+}
+
+#[async_trait::async_trait]
+impl SubscriptionClientT for Rpc {
+    async fn subscribe<'a, Notif, Params>(
+        &self,
+        subscribe_method: &'a str,
+        params: Params,
+        _unsubscribe_method: &'a str,
+    ) -> Result<jsonrpsee_core::client::Subscription<Notif>, Error>
+    where
+        Params: ToRpcParams + Send,
+        Notif: DeserializeOwned,
+    {
+        let mut subscription = Arc::clone(&self.inner).subscribe(subscribe_method, params).await?;
+        let kind = subscription.subscription_id().clone().into_owned();
+        let (to_back, _) = futures::channel::mpsc::channel(10);
+        let (mut notifs_tx, notifs_rx) = futures::channel::mpsc::channel(10);
+        tokio::spawn(async move {
+            while let Some(result) = subscription.next().await {
+                let Ok((item, _)) = result else { break };
+                if notifs_tx.send(item).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(Subscription::new(to_back, notifs_rx, SubscriptionKind::Subscription(kind)))
+    }
+
+    async fn subscribe_to_method<'a, Notif>(
+        &self,
+        _method: &'a str,
+    ) -> Result<jsonrpsee_core::client::Subscription<Notif>, Error>
+    where
+        Notif: DeserializeOwned,
+    {
+        unreachable!("It isn't called")
+    }
+}


### PR DESCRIPTION
This is a technical pr. Beforehand, I used low level bindings for node rpc. This pr migrates to handmade offline json rpc client wrapper and reuses traits from substrate.