### PR TITLE
Fix syncing and record storage bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8966,6 +8966,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backoff",
  "base58",
  "blake2",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
+backoff = "0.4"
 base58 = "0.2"
 blake2 = "0.10.5"
 bytesize = "1.1"

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -163,7 +163,7 @@ impl<A: subspace_networking::RecordStorage, B: subspace_networking::RecordStorag
         &'_ self,
         k: &subspace_networking::libp2p::kad::record::Key,
     ) -> Option<std::borrow::Cow<'_, subspace_networking::libp2p::kad::Record>> {
-        self.a.get(k)
+        self.a.get(k).or_else(|| self.b.get(k))
     }
 
     fn put(


### PR DESCRIPTION
After this is merged, we can revert to using substrate mechanism without `backoff`:
https://github.com/subspace/subspace/pull/1050