### PR TITLE
Fix toml serialization and minimize config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9022,6 +9022,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "toml",
  "tracing",
  "tracing-subscriber 0.3.16",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "f
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
+toml = "0.5"
 tempfile = "3.3"
 tokio = { version = "1.21", features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = "0.3"

--- a/src/farmer.rs
+++ b/src/farmer.rs
@@ -120,22 +120,68 @@ mod builder {
 
     use derivative::Derivative;
     use derive_builder::Builder;
+    use derive_more::{Deref, DerefMut, Display, From};
     use serde::{Deserialize, Serialize};
 
     use super::{BuildError, CacheDescription};
     use crate::{Farmer, Node, PlotDescription, PublicKey};
 
-    fn default_piece_receiver_batch_size() -> NonZeroUsize {
-        NonZeroUsize::new(12).unwrap()
-    }
+    #[derive(
+        Debug,
+        Clone,
+        Derivative,
+        Deserialize,
+        Serialize,
+        PartialEq,
+        Eq,
+        From,
+        Deref,
+        DerefMut,
+        Display,
+    )]
+    #[derivative(Default)]
+    #[serde(transparent)]
+    pub struct PiecePublisherBatchSize(
+        #[derivative(Default(value = "NonZeroUsize::new(12).unwrap()"))] pub(crate) NonZeroUsize,
+    );
 
-    fn default_piece_publisher_batch_size() -> NonZeroUsize {
-        NonZeroUsize::new(12).unwrap()
-    }
+    #[derive(
+        Debug,
+        Clone,
+        Derivative,
+        Deserialize,
+        Serialize,
+        PartialEq,
+        Eq,
+        From,
+        Deref,
+        DerefMut,
+        Display,
+    )]
+    #[derivative(Default)]
+    #[serde(transparent)]
+    pub struct PieceReceiverBatchSize(
+        #[derivative(Default(value = "NonZeroUsize::new(12).unwrap()"))] pub(crate) NonZeroUsize,
+    );
 
-    fn default_max_concurrent_plots() -> NonZeroUsize {
-        NonZeroUsize::new(10).unwrap()
-    }
+    #[derive(
+        Debug,
+        Clone,
+        Derivative,
+        Deserialize,
+        Serialize,
+        PartialEq,
+        Eq,
+        From,
+        Deref,
+        DerefMut,
+        Display,
+    )]
+    #[derivative(Default)]
+    #[serde(transparent)]
+    pub struct MaxConcurrentPlots(
+        #[derivative(Default(value = "NonZeroUsize::new(10).unwrap()"))] pub(crate) NonZeroUsize,
+    );
 
     /// Technical type which stores all
     #[derive(Debug, Clone, Derivative, Builder, Serialize, Deserialize)]
@@ -144,20 +190,17 @@ mod builder {
     #[non_exhaustive]
     pub struct Config {
         /// Defines size for the pieces batch of the piece receiving process.
-        #[builder(default = "default_piece_receiver_batch_size()")]
-        #[derivative(Default(value = "default_piece_receiver_batch_size()"))]
-        #[serde(default = "default_piece_receiver_batch_size")]
-        pub piece_receiver_batch_size: NonZeroUsize,
+        #[builder(default, setter(into))]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+        pub piece_receiver_batch_size: PieceReceiverBatchSize,
         /// Defines size for the pieces batch of the piece publishing process.
-        #[builder(default = "default_piece_publisher_batch_size()")]
-        #[derivative(Default(value = "default_piece_publisher_batch_size()"))]
-        #[serde(default = "default_piece_publisher_batch_size")]
-        pub piece_publisher_batch_size: NonZeroUsize,
+        #[builder(default, setter(into))]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+        pub piece_publisher_batch_size: PiecePublisherBatchSize,
         /// Number of plots that can be plotted concurrently, impacts RAM usage.
-        #[builder(default = "default_max_concurrent_plots()")]
-        #[derivative(Default(value = "default_max_concurrent_plots()"))]
-        #[serde(default = "default_max_concurrent_plots")]
-        pub max_concurrent_plots: NonZeroUsize,
+        #[builder(default, setter(into))]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+        pub max_concurrent_plots: MaxConcurrentPlots,
     }
 
     impl Builder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,7 @@ enabled = false
 indexing_enabled = false
 "#,
             "piece_cache_size = \"1073.7 MB\"\nsegment_publish_concurrency = 10",
+            r#""#,
         ];
         const DEFAULT_FARMER_CONFIGS: &'static [&'static str] = &[
             r#"
@@ -311,6 +312,7 @@ piece_receiver_batch_size = 12
 piece_publisher_batch_size = 12
 max_concurrent_plots = 10
 "#,
+            r#""#,
         ];
 
         for node in DEFAULT_NODE_CONFIGS {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,4 +261,65 @@ mod tests {
             assert!(slot_info_sub.next().await.is_some());
         }
     }
+
+    #[test]
+    fn check_toml_serializable_max() {
+        const DEFAULT_NODE_CONFIGS: &'static [&'static str] = &[
+            r#"
+piece_cache_size = "1073.7 MB"
+segment_publish_concurrency = 10
+force_authoring = false
+role = "Full"
+blocks_pruning = "KeepAll"
+state_pruning = "ArchiveAll"
+execution_strategy = "NativeWhenPossible"
+impl_name = "subspace-sdk"
+impl_version = "0.1.0-c88c59ab7a7cae3518b224302a3c96beb7c5afaf"
+
+[rpc]
+methods = "Auto"
+max_subs_per_conn = 1024
+
+[network]
+enable_mdns = false
+allow_private_ipv4 = false
+listen_addresses = []
+boot_nodes = []
+force_synced = false
+
+[offchain_worker]
+enabled = false
+indexing_enabled = false
+"#,
+            "piece_cache_size = \"1073.7 MB\"\nsegment_publish_concurrency = 10",
+        ];
+        const DEFAULT_FARMER_CONFIGS: &'static [&'static str] = &[
+            r#"
+[dsn]
+listen_addresses = ["/ip4/127.0.0.1/tcp/0"]
+boot_nodes = []
+reserved_nodes = []
+allow_non_global_addresses_in_dht = false
+piece_publisher_batch_size = 15
+
+piece_receiver_batch_size = 12
+piece_publisher_batch_size = 12
+max_concurrent_plots = 10
+"#,
+            r#"
+piece_receiver_batch_size = 12
+piece_publisher_batch_size = 12
+max_concurrent_plots = 10
+"#,
+        ];
+
+        for node in DEFAULT_NODE_CONFIGS {
+            let node = toml::from_str::<node::Config>(node).unwrap();
+            toml::to_string(&node).unwrap();
+        }
+        for farmer in DEFAULT_FARMER_CONFIGS {
+            let farmer = toml::from_str::<farmer::Config>(farmer).unwrap();
+            toml::to_string(&farmer).unwrap();
+        }
+    }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -54,7 +54,9 @@ mod builder {
     use super::*;
 
     /// Block pruning settings.
-    #[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+    #[derive(
+        Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize, Eq, PartialOrd, Ord,
+    )]
     pub enum BlocksPruning {
         #[default]
         /// Keep full block history, of every block that was ever imported.
@@ -198,18 +200,11 @@ mod builder {
     }
 
     /// Node builder
-    #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize)]
+    #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize, PartialEq)]
     #[derivative(Default)]
     #[builder(pattern = "immutable", build_fn(private, name = "_build"), name = "Builder")]
     #[non_exhaustive]
     pub struct Config {
-        #[doc(hidden)]
-        #[builder(
-            setter(into, strip_option),
-            field(type = "BaseBuilder", build = "self.base.build()")
-        )]
-        #[serde(default)]
-        pub base: Base,
         /// Set piece cache size
         #[builder(default = "default_piece_cache_size()")]
         #[derivative(Default(value = "default_piece_cache_size()"))]
@@ -221,9 +216,16 @@ mod builder {
         #[derivative(Default(value = "default_segment_publish_concurrency()"))]
         #[serde(default = "default_segment_publish_concurrency")]
         pub segment_publish_concurrency: NonZeroUsize,
+        #[doc(hidden)]
+        #[builder(
+            setter(into, strip_option),
+            field(type = "BaseBuilder", build = "self.base.build()")
+        )]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+        pub base: Base,
         /// DSN settings
         #[builder(setter(into), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub dsn: Dsn,
     }
 
@@ -236,30 +238,30 @@ mod builder {
     }
 
     #[doc(hidden)]
-    #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize)]
+    #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize, PartialEq)]
     #[derivative(Default)]
     #[builder(pattern = "immutable", build_fn(private, name = "_build"), name = "BaseBuilder")]
     #[non_exhaustive]
     pub struct Base {
         /// Force block authoring
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub force_authoring: bool,
         /// Set node role
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub role: Role,
         /// Blocks pruning options
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub blocks_pruning: BlocksPruning,
         /// State pruning options
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub state_pruning: PruningMode,
         /// Set execution strategies
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub execution_strategy: ExecutionStrategy,
         /// Implementation name
         #[builder(default = "default_impl_name()")]
@@ -273,15 +275,15 @@ mod builder {
         pub impl_version: String,
         /// Rpc settings
         #[builder(setter(into), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub rpc: Rpc,
         /// Network settings
         #[builder(setter(into), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub network: Network,
         /// Offchain worker settings
         #[builder(setter(into), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub offchain_worker: OffchainWorker,
     }
 
@@ -423,49 +425,49 @@ mod builder {
     }
 
     /// Node RPC builder
-    #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize)]
+    #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize, PartialEq, Eq)]
     #[derivative(Default)]
     #[builder(pattern = "immutable", build_fn(private, name = "_build"), name = "RpcBuilder")]
     #[non_exhaustive]
     pub struct Rpc {
         /// RPC over HTTP binding address. `None` if disabled.
         #[builder(setter(strip_option), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub http: Option<SocketAddr>,
         /// RPC over Websockets binding address. `None` if disabled.
         #[builder(setter(strip_option), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub ws: Option<SocketAddr>,
         /// RPC over IPC binding path. `None` if disabled.
         #[builder(setter(strip_option), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub ipc: Option<String>,
         /// Maximum number of connections for WebSockets RPC server. `None` if
         /// default.
         #[builder(setter(strip_option), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub ws_max_connections: Option<usize>,
         /// CORS settings for HTTP & WS servers. `None` if all origins are
         /// allowed.
         #[builder(setter(strip_option), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub cors: Option<Vec<String>>,
         /// RPC methods to expose (by default only a safe subset or all of
         /// them).
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub methods: RpcMethods,
         /// Maximum payload of rpc request/responses.
         #[builder(setter(strip_option), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub max_payload: Option<usize>,
         /// Maximum payload of a rpc request
         #[builder(setter(strip_option), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub max_request_size: Option<usize>,
         /// Maximum payload of a rpc request
         #[builder(setter(strip_option), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub max_response_size: Option<usize>,
         /// Maximum allowed subscriptions per rpc connection
         #[builder(default = "default_max_subs_per_conn()")]
@@ -475,42 +477,42 @@ mod builder {
         /// Maximum size of the output buffer capacity for websocket
         /// connections.
         #[builder(setter(strip_option), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub ws_max_out_buffer_capacity: Option<usize>,
     }
 
     /// Node network builder
-    #[derive(Debug, Default, Clone, Builder, Deserialize, Serialize)]
+    #[derive(Debug, Default, Clone, Builder, Deserialize, Serialize, PartialEq)]
     #[builder(pattern = "immutable", build_fn(private, name = "_build"), name = "NetworkBuilder")]
     #[non_exhaustive]
     pub struct Network {
         /// Listen on some address for other nodes
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub enable_mdns: bool,
         /// Listen on some address for other nodes
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub allow_private_ipv4: bool,
         /// Listen on some address for other nodes
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub listen_addresses: Vec<Multiaddr>,
         /// Boot nodes
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         pub boot_nodes: Vec<MultiaddrWithPeerId>,
         /// Force node to think it is synced
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub force_synced: bool,
         /// Node name
         #[builder(setter(into, strip_option), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub name: Option<String>,
         /// Client id for telemetry (default is `{IMPL_NAME}/v{IMPL_VERSION}`)
         #[builder(setter(into, strip_option), default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub client_id: Option<String>,
     }
 
@@ -524,7 +526,7 @@ mod builder {
     }
 
     /// Node DSN builder
-    #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize)]
+    #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize, PartialEq, Eq)]
     #[derivative(Default)]
     #[builder(pattern = "immutable", build_fn(private, name = "_build"), name = "DsnBuilder")]
     #[non_exhaustive]
@@ -536,18 +538,18 @@ mod builder {
         pub listen_addresses: Vec<libp2p_core::Multiaddr>,
         /// Boot nodes
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub boot_nodes: Vec<libp2p_core::Multiaddr>,
         /// Reserved nodes
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub reserved_nodes: Vec<libp2p_core::Multiaddr>,
         /// Determines whether we allow keeping non-global (private, shared,
         /// loopback..) addresses in Kademlia DHT.
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub allow_non_global_addresses_in_dht: bool,
-        /// Sets piece publШрек чтолиisher batch size
+        /// Sets piece publisher batch size
         #[builder(default = "default_piece_publisher_batch_size()")]
         #[derivative(Default(value = "default_piece_publisher_batch_size()"))]
         #[serde(default = "default_piece_publisher_batch_size")]
@@ -555,18 +557,18 @@ mod builder {
     }
 
     /// Offchain worker config
-    #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize)]
+    #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize, PartialEq, Eq)]
     #[derivative(Default)]
     #[builder(pattern = "immutable", build_fn(name = "_build"), name = "OffchainWorkerBuilder")]
     #[non_exhaustive]
     pub struct OffchainWorker {
         /// Is enabled
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub enabled: bool,
         /// Is indexing enabled
         #[builder(default)]
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub indexing_enabled: bool,
     }
 
@@ -623,7 +625,7 @@ mod builder {
 }
 
 /// Role of the local node.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Role {
     #[default]
     /// Regular full node.
@@ -642,7 +644,7 @@ impl From<Role> for sc_service::Role {
 }
 
 /// Available RPC methods.
-#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub enum RpcMethods {
     /// Expose every RPC method only when RPC is listening on `localhost`,
     /// otherwise serve only safe RPC methods.

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -39,6 +39,7 @@ pub use builder::{
     Rpc, RpcBuilder,
 };
 
+use self::builder::{ListenAddresses, PiecePublisherBatchSize, SegmentPublishConcurrency};
 use crate::networking::{
     FarmerRecordStorage, MaybeRecordStorage, NodeRecordStorage, ReadersAndPieces, RecordStorage,
 };
@@ -49,6 +50,7 @@ mod builder {
 
     use derivative::Derivative;
     use derive_builder::Builder;
+    use derive_more::{Deref, DerefMut, Display, From};
     use serde::{Deserialize, Serialize};
 
     use super::*;
@@ -191,13 +193,45 @@ mod builder {
         }
     }
 
-    fn default_piece_cache_size() -> bytesize::ByteSize {
-        bytesize::ByteSize::gib(1)
-    }
+    #[derive(
+        Debug,
+        Clone,
+        Derivative,
+        Deserialize,
+        Serialize,
+        PartialEq,
+        Eq,
+        From,
+        Deref,
+        DerefMut,
+        Display,
+    )]
+    #[derivative(Default)]
+    #[serde(transparent)]
+    pub struct PieceCacheSize(
+        #[derivative(Default(value = "bytesize::ByteSize::gib(1)"))]
+        #[serde(with = "bytesize_serde")]
+        pub(crate) bytesize::ByteSize,
+    );
 
-    fn default_segment_publish_concurrency() -> NonZeroUsize {
-        NonZeroUsize::new(10).unwrap()
-    }
+    #[derive(
+        Debug,
+        Clone,
+        Derivative,
+        Deserialize,
+        Serialize,
+        PartialEq,
+        Eq,
+        From,
+        Deref,
+        DerefMut,
+        Display,
+    )]
+    #[derivative(Default)]
+    #[serde(transparent)]
+    pub struct SegmentPublishConcurrency(
+        #[derivative(Default(value = "NonZeroUsize::new(10).unwrap()"))] pub(crate) NonZeroUsize,
+    );
 
     /// Node builder
     #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize, PartialEq)]
@@ -206,22 +240,20 @@ mod builder {
     #[non_exhaustive]
     pub struct Config {
         /// Set piece cache size
-        #[builder(default = "default_piece_cache_size()")]
-        #[derivative(Default(value = "default_piece_cache_size()"))]
-        #[serde(with = "bytesize_serde", default = "default_piece_cache_size")]
-        pub piece_cache_size: bytesize::ByteSize,
+        #[builder(setter(into), default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+        pub piece_cache_size: PieceCacheSize,
         /// Max number of segments that can be published concurrently, impacts
         /// RAM usage and network bandwidth.
-        #[builder(default = "default_segment_publish_concurrency()")]
-        #[derivative(Default(value = "default_segment_publish_concurrency()"))]
-        #[serde(default = "default_segment_publish_concurrency")]
-        pub segment_publish_concurrency: NonZeroUsize,
+        #[builder(setter(into), default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+        pub segment_publish_concurrency: SegmentPublishConcurrency,
         #[doc(hidden)]
         #[builder(
             setter(into, strip_option),
             field(type = "BaseBuilder", build = "self.base.build()")
         )]
-        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+        #[serde(flatten, skip_serializing_if = "crate::utils::is_default")]
         pub base: Base,
         /// DSN settings
         #[builder(setter(into), default)]
@@ -229,13 +261,46 @@ mod builder {
         pub dsn: Dsn,
     }
 
-    fn default_impl_name() -> String {
-        env!("CARGO_PKG_NAME").to_owned()
-    }
+    #[derive(
+        Debug,
+        Clone,
+        Derivative,
+        Deserialize,
+        Serialize,
+        PartialEq,
+        Eq,
+        From,
+        Deref,
+        DerefMut,
+        Display,
+    )]
+    #[derivative(Default)]
+    #[serde(transparent)]
+    pub struct ImplName(
+        #[derivative(Default(value = "env!(\"CARGO_PKG_NAME\").to_owned()"))] pub(crate) String,
+    );
 
-    fn default_impl_version() -> String {
-        format!("{}-{}", env!("CARGO_PKG_VERSION"), env!("GIT_HASH"))
-    }
+    #[derive(
+        Debug,
+        Clone,
+        Derivative,
+        Deserialize,
+        Serialize,
+        PartialEq,
+        Eq,
+        From,
+        Deref,
+        DerefMut,
+        Display,
+    )]
+    #[derivative(Default)]
+    #[serde(transparent)]
+    pub struct ImplVersion(
+        #[derivative(Default(
+            value = "format!(\"{}-{}\", env!(\"CARGO_PKG_VERSION\"), env!(\"GIT_HASH\"))"
+        ))]
+        pub(crate) String,
+    );
 
     #[doc(hidden)]
     #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize, PartialEq)]
@@ -264,15 +329,13 @@ mod builder {
         #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub execution_strategy: ExecutionStrategy,
         /// Implementation name
-        #[builder(default = "default_impl_name()")]
-        #[derivative(Default(value = "default_impl_name()"))]
-        #[serde(default = "default_impl_name")]
-        pub impl_name: String,
+        #[builder(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+        pub impl_name: ImplName,
         /// Implementation version
-        #[builder(default = "default_impl_version()")]
-        #[derivative(Default(value = "default_impl_version()"))]
-        #[serde(default = "default_impl_version")]
-        pub impl_version: String,
+        #[builder(default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+        pub impl_version: ImplVersion,
         /// Rpc settings
         #[builder(setter(into), default)]
         #[serde(default, skip_serializing_if = "crate::utils::is_default")]
@@ -302,8 +365,8 @@ mod builder {
                 blocks_pruning,
                 state_pruning,
                 execution_strategy,
-                impl_name,
-                impl_version,
+                impl_name: ImplName(impl_name),
+                impl_version: ImplVersion(impl_version),
                 rpc:
                     Rpc {
                         http: rpc_http,
@@ -420,9 +483,22 @@ mod builder {
         }
     }
 
-    fn default_max_subs_per_conn() -> usize {
-        1024
-    }
+    #[derive(
+        Debug,
+        Clone,
+        Derivative,
+        Deserialize,
+        Serialize,
+        PartialEq,
+        Eq,
+        From,
+        Deref,
+        DerefMut,
+        Display,
+    )]
+    #[derivative(Default)]
+    #[serde(transparent)]
+    pub struct MaxSubsPerConn(#[derivative(Default(value = "1024"))] pub(crate) usize);
 
     /// Node RPC builder
     #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize, PartialEq, Eq)]
@@ -470,9 +546,8 @@ mod builder {
         #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub max_response_size: Option<usize>,
         /// Maximum allowed subscriptions per rpc connection
-        #[builder(default = "default_max_subs_per_conn()")]
-        #[derivative(Default(value = "default_max_subs_per_conn()"))]
-        #[serde(default = "default_max_subs_per_conn")]
+        #[builder(setter(into), default)]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub max_subs_per_conn: usize,
         /// Maximum size of the output buffer capacity for websocket
         /// connections.
@@ -516,14 +591,35 @@ mod builder {
         pub client_id: Option<String>,
     }
 
-    fn default_listen_addresses() -> Vec<libp2p_core::Multiaddr> {
+    #[derive(
+        Debug, Clone, Derivative, Deserialize, Serialize, PartialEq, Eq, From, Deref, DerefMut,
+    )]
+    #[derivative(Default)]
+    #[serde(transparent)]
+    pub struct ListenAddresses(
+        #[derivative(Default(
         // TODO: get rid of it, once it won't be required by monorepo
-        vec!["/ip4/127.0.0.1/tcp/0".parse().expect("Always valid")]
-    }
+            value = "vec![\"/ip4/127.0.0.1/tcp/0\".parse().expect(\"Always valid\")]"
+        ))]
+        pub(crate) Vec<libp2p_core::Multiaddr>,
+    );
 
-    fn default_piece_publisher_batch_size() -> usize {
-        15
-    }
+    #[derive(
+        Debug,
+        Clone,
+        Derivative,
+        Deserialize,
+        Serialize,
+        PartialEq,
+        Eq,
+        From,
+        Deref,
+        DerefMut,
+        Display,
+    )]
+    #[derivative(Default)]
+    #[serde(transparent)]
+    pub struct PiecePublisherBatchSize(#[derivative(Default(value = "15"))] pub(crate) usize);
 
     /// Node DSN builder
     #[derive(Debug, Clone, Derivative, Builder, Deserialize, Serialize, PartialEq, Eq)]
@@ -532,10 +628,9 @@ mod builder {
     #[non_exhaustive]
     pub struct Dsn {
         /// Listen on some address for other nodes
-        #[builder(default = "default_listen_addresses()")]
-        #[derivative(Default(value = "default_listen_addresses()"))]
-        #[serde(default = "default_listen_addresses")]
-        pub listen_addresses: Vec<libp2p_core::Multiaddr>,
+        #[builder(default, setter(into))]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+        pub listen_addresses: ListenAddresses,
         /// Boot nodes
         #[builder(default)]
         #[serde(default, skip_serializing_if = "crate::utils::is_default")]
@@ -550,10 +645,9 @@ mod builder {
         #[serde(default, skip_serializing_if = "crate::utils::is_default")]
         pub allow_non_global_addresses_in_dht: bool,
         /// Sets piece publisher batch size
-        #[builder(default = "default_piece_publisher_batch_size()")]
-        #[derivative(Default(value = "default_piece_publisher_batch_size()"))]
-        #[serde(default = "default_piece_publisher_batch_size")]
-        pub piece_publisher_batch_size: usize,
+        #[builder(default, setter(into))]
+        #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+        pub piece_publisher_batch_size: PiecePublisherBatchSize,
     }
 
     /// Offchain worker config
@@ -611,9 +705,9 @@ mod builder {
         /// Set execution strategies
         execution_strategy: ExecutionStrategy,
         /// Implementation name
-        impl_name: String,
+        impl_name: ImplName,
         /// Implementation version
-        impl_version: String,
+        impl_version: ImplVersion,
         /// Rpc settings
         rpc: Rpc,
         /// Network settings
@@ -675,7 +769,12 @@ impl Config {
         directory: impl AsRef<Path>,
         chain_spec: ConsensusChainSpec<ConsensusGenesisConfig, ExecutionGenesisConfig>,
     ) -> anyhow::Result<Node> {
-        let Self { base, piece_cache_size, dsn, segment_publish_concurrency } = self;
+        let Self {
+            base,
+            piece_cache_size,
+            dsn,
+            segment_publish_concurrency: SegmentPublishConcurrency(segment_publish_concurrency),
+        } = self;
         let base = base.configuration(directory, chain_spec).await;
         let name = base.network.node_name.clone();
 
@@ -687,11 +786,11 @@ impl Config {
 
         let (subspace_networking, (node, mut node_runner)) = {
             let builder::Dsn {
-                listen_addresses,
+                listen_addresses: ListenAddresses(listen_addresses),
                 boot_nodes,
                 reserved_nodes: _,
                 allow_non_global_addresses_in_dht,
-                piece_publisher_batch_size,
+                piece_publisher_batch_size: PiecePublisherBatchSize(piece_publisher_batch_size),
             } = dsn;
             let keypair = {
                 let keypair = base

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -88,3 +88,7 @@ impl SubscriptionClientT for Rpc {
         unreachable!("It isn't called")
     }
 }
+
+pub fn is_default<T: Default + PartialEq>(t: &T) -> bool {
+    t == &T::default()
+}


### PR DESCRIPTION
This pr fixes toml bug and lets config look like this:
```toml
piece_cache_size = "1073.7 MB"
segment_publish_concurrency = 10
```
or even like nothing, instead of:
```toml
piece_cache_size = "1073.7 MB"
segment_publish_concurrency = 10
force_authoring = false
role = "Full"
blocks_pruning = "KeepAll"
state_pruning = "ArchiveAll"
execution_strategy = "NativeWhenPossible"
impl_name = "subspace-sdk"
impl_version = "0.1.0-c88c59ab7a7cae3518b224302a3c96beb7c5afaf"

[rpc]
methods = "Auto"
max_subs_per_conn = 1024

[network]
enable_mdns = false
allow_private_ipv4 = false
listen_addresses = []
boot_nodes = []
force_synced = false

[offchain_worker]
enabled = false
indexing_enabled = false
```

Basically, fields are omitted during serialization if they are default.