### PR TITLE
Update monorepo and make SDK working on Gemini 3c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "core-payments-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "futures 0.3.26",
  "parity-scale-codec",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "domain-block-builder"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -2023,7 +2023,7 @@ dependencies = [
 [[package]]
 name = "domain-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "async-trait",
  "parking_lot 0.12.1",
@@ -2039,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "domain-client-executor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "crossbeam",
  "domain-block-builder",
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "domain-client-executor-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "futures 0.3.26",
  "parity-scale-codec",
@@ -2104,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "domain-client-message-relayer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "cross-domain-message-gossip",
  "domain-runtime-primitives",
@@ -2129,7 +2129,7 @@ dependencies = [
 [[package]]
 name = "domain-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2146,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2158,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "domain-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "clap",
  "cross-domain-message-gossip",
@@ -5533,7 +5533,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5630,7 +5630,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5651,7 +5651,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5668,7 +5668,7 @@ dependencies = [
 [[package]]
 name = "pallet-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5686,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5702,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -5722,7 +5722,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5742,7 +5742,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5757,7 +5757,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5772,7 +5772,7 @@ dependencies = [
 [[package]]
 name = "pallet-receipts"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5788,7 +5788,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5801,7 +5801,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5813,7 +5813,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5869,7 +5869,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5925,7 +5925,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7264,7 +7264,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -7302,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -7343,7 +7343,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "async-oneshot",
  "futures 0.3.26",
@@ -7863,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -8603,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "async-trait",
  "log",
@@ -8717,7 +8717,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8729,7 +8729,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "blake2",
  "merlin 2.0.1",
@@ -8755,7 +8755,7 @@ dependencies = [
 [[package]]
 name = "sp-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "parity-scale-codec",
  "sp-domains",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -8885,7 +8885,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -9316,7 +9316,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "parity-scale-codec",
  "reed-solomon-erasure",
@@ -9328,7 +9328,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "ark-bls12-381",
  "ark-ff",
@@ -9356,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9405,7 +9405,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "async-trait",
  "fs2",
@@ -9428,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -9447,7 +9447,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -9484,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "hex",
  "serde",
@@ -9496,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -9549,7 +9549,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9648,7 +9648,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "derive_more",
  "domain-runtime-primitives",
@@ -9711,7 +9711,7 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "merlin 2.0.1",
  "schnorrkel",
@@ -9721,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "subspace-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "domain-runtime-primitives",
  "futures 0.3.26",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -9765,7 +9765,7 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "sc-executor-common",
  "sp-domains",
@@ -9902,7 +9902,7 @@ dependencies = [
 [[package]]
 name = "system-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "core-payments-domain-runtime",
  "domain-pallet-executive",
@@ -9945,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "system-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
+source = "git+https://github.com/subspace/subspace?rev=145e78c0935f2d839f75deedc1874f34235cd59a#145e78c0935f2d839f75deedc1874f34235cd59a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "core-payments-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "futures 0.3.26",
  "parity-scale-codec",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "domain-block-builder"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -2023,7 +2023,7 @@ dependencies = [
 [[package]]
 name = "domain-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "async-trait",
  "parking_lot 0.12.1",
@@ -2039,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "domain-client-executor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "crossbeam",
  "domain-block-builder",
@@ -2055,6 +2055,7 @@ dependencies = [
  "sc-consensus",
  "sc-executor",
  "sc-network",
+ "sc-transaction-pool",
  "sc-transaction-pool-api",
  "sc-utils",
  "schnorrkel",
@@ -2067,11 +2068,14 @@ dependencies = [
  "sp-domain-digests",
  "sp-domains",
  "sp-keystore",
+ "sp-messenger",
  "sp-runtime",
+ "sp-transaction-pool",
  "sp-trie",
  "subspace-core-primitives",
  "subspace-fraud-proof",
  "subspace-runtime-primitives",
+ "subspace-transaction-pool",
  "subspace-wasm-tools",
  "system-runtime-primitives",
  "thiserror",
@@ -2082,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "domain-client-executor-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "futures 0.3.26",
  "parity-scale-codec",
@@ -2100,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "domain-client-message-relayer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "cross-domain-message-gossip",
  "domain-runtime-primitives",
@@ -2125,7 +2129,7 @@ dependencies = [
 [[package]]
 name = "domain-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2142,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2154,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "domain-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "clap",
  "cross-domain-message-gossip",
@@ -5529,7 +5533,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5626,7 +5630,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5647,7 +5651,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5664,7 +5668,7 @@ dependencies = [
 [[package]]
 name = "pallet-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5682,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5698,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -5718,7 +5722,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5738,7 +5742,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5753,7 +5757,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5768,7 +5772,7 @@ dependencies = [
 [[package]]
 name = "pallet-receipts"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5784,7 +5788,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5797,18 +5801,19 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5864,7 +5869,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5920,7 +5925,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7259,7 +7264,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -7297,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -7338,7 +7343,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "async-oneshot",
  "futures 0.3.26",
@@ -7858,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -8598,7 +8603,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "async-trait",
  "log",
@@ -8712,7 +8717,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8724,7 +8729,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "blake2",
  "merlin 2.0.1",
@@ -8750,7 +8755,7 @@ dependencies = [
 [[package]]
 name = "sp-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "parity-scale-codec",
  "sp-domains",
@@ -8865,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -8880,7 +8885,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -9311,7 +9316,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "parity-scale-codec",
  "reed-solomon-erasure",
@@ -9323,7 +9328,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "ark-bls12-381",
  "ark-ff",
@@ -9351,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9400,7 +9405,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "async-trait",
  "fs2",
@@ -9423,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -9442,7 +9447,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -9479,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "hex",
  "serde",
@@ -9491,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -9544,7 +9549,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9643,7 +9648,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "derive_more",
  "domain-runtime-primitives",
@@ -9706,7 +9711,7 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "merlin 2.0.1",
  "schnorrkel",
@@ -9716,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "subspace-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "domain-runtime-primitives",
  "futures 0.3.26",
@@ -9743,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "merlin 2.0.1",
  "parity-scale-codec",
@@ -9760,7 +9765,7 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "sc-executor-common",
  "sp-domains",
@@ -9897,7 +9902,7 @@ dependencies = [
 [[package]]
 name = "system-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "core-payments-domain-runtime",
  "domain-pallet-executive",
@@ -9940,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "system-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=f95d048756bf79ee93732f7a4fd6eb99504df750#f95d048756bf79ee93732f7a4fd6eb99504df750"
+source = "git+https://github.com/subspace/subspace?rev=52cbb440db845dc1f8fa12987afc679e620ab116#52cbb440db845dc1f8fa12987afc679e620ab116"
 dependencies = [
  "parity-scale-codec",
  "sp-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,29 +62,29 @@ sp-session = { version = "4.0.0-dev", git = "https://github.com/subspace/substra
 sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "100d6c90d4122578006a47c1dcaf155b9c685f34" }
 sp-version = { version = "5.0.0", git = "https://github.com/subspace/substrate", rev = "100d6c90d4122578006a47c1dcaf155b9c685f34" }
 
-core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-cross-domain-message-gossip = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-domain-client-message-relayer = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-domain-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-domain-service = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-sp-domains = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-sp-objects = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-subspace-transaction-pool = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
-system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "f95d048756bf79ee93732f7a4fd6eb99504df750" }
+core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+cross-domain-message-gossip = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+domain-client-message-relayer = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+domain-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+domain-service = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+sp-domains = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+sp-objects = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+subspace-transaction-pool = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,29 +62,29 @@ sp-session = { version = "4.0.0-dev", git = "https://github.com/subspace/substra
 sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "100d6c90d4122578006a47c1dcaf155b9c685f34" }
 sp-version = { version = "5.0.0", git = "https://github.com/subspace/substrate", rev = "100d6c90d4122578006a47c1dcaf155b9c685f34" }
 
-core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-cross-domain-message-gossip = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-domain-client-message-relayer = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-domain-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-domain-service = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-sp-domains = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-sp-objects = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-subspace-transaction-pool = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
-system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "52cbb440db845dc1f8fa12987afc679e620ab116" }
+core-payments-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+cross-domain-message-gossip = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+domain-client-message-relayer = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+domain-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+domain-service = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+sp-domains = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+sp-objects = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+subspace-archiving = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+subspace-transaction-pool = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
+system-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "145e78c0935f2d839f75deedc1874f34235cd59a" }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/src/node/chain_spec.rs
+++ b/src/node/chain_spec.rs
@@ -45,6 +45,7 @@ pub struct GenesisParams {
     allow_authoring_by: AllowAuthoringBy,
     enable_executor: bool,
     enable_transfer: bool,
+    confirmation_depth_k: u32,
 }
 
 /// Chain spec type for the subspace
@@ -122,6 +123,7 @@ pub fn gemini_3c_compiled() -> Result<ChainSpec, String> {
                         ]),
                     ),
                     enable_executor: true,
+                    confirmation_depth_k: 100, // TODO: Proper value here
                 },
             )
         },
@@ -204,6 +206,7 @@ pub fn devnet_config_compiled() -> Result<ChainSpec, String> {
                     allow_authoring_by: AllowAuthoringBy::FirstFarmer,
                     enable_executor: true,
                     enable_transfer: true,
+                    confirmation_depth_k: 100, // TODO: Proper value here
                 },
             )
         },
@@ -253,6 +256,7 @@ pub fn dev_config() -> Result<ChainSpec, String> {
                     enable_storage_access: false,
                     allow_authoring_by: AllowAuthoringBy::Anyone,
                     enable_executor: true,
+                    confirmation_depth_k: 1,
                 },
             )
         },
@@ -309,6 +313,7 @@ pub fn local_config() -> Result<ChainSpec, String> {
                     enable_storage_access: false,
                     allow_authoring_by: AllowAuthoringBy::Anyone,
                     enable_executor: true,
+                    confirmation_depth_k: 1,
                 },
             )
         },
@@ -343,6 +348,7 @@ fn subspace_genesis_config(
         allow_authoring_by,
         enable_executor,
         enable_transfer,
+        confirmation_depth_k,
     } = genesis_params;
 
     GenesisConfig {
@@ -358,7 +364,11 @@ fn subspace_genesis_config(
         },
         subspace: SubspaceConfig { enable_rewards, enable_storage_access, allow_authoring_by },
         vesting: VestingConfig { vesting },
-        runtime_configs: RuntimeConfigsConfig { enable_executor, enable_transfer },
+        runtime_configs: RuntimeConfigsConfig {
+            enable_executor,
+            enable_transfer,
+            confirmation_depth_k,
+        },
     }
 }
 


### PR DESCRIPTION
With this pr plotting and DSN syncing finally works on gemini 3c!

You can test sdk running a following command:
```sh
$ cargo run \
    --release \
    --example gemini-3c\
    --
        --reward-address ... \
        --plot-size ...
```