### PR TITLE
Handle disconnect during syncing

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1604,6 +1604,8 @@ impl Node {
             self.network.status().map(|result| match result.map(|status| status.sync_state) {
                 Ok(SyncState::Importing { target }) => Ok((target, SyncStatus::Importing)),
                 Ok(SyncState::Downloading { target }) => Ok((target, SyncStatus::Downloading)),
+                _ if self.network.is_offline() =>
+                    Err(backoff::Error::transient(Some(anyhow::anyhow!("Node went offline")))),
                 Err(()) => Err(backoff::Error::transient(Some(anyhow::anyhow!(
                     "Failed to fetch networking status"
                 )))),


### PR DESCRIPTION
Closes  #145

This pr makes sure that if the node gets disconnected from the network, the user receives on error after timing out.