### PR TITLE
Add trait derive for custom bytesize and export necessary things from `node`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,9 @@ pub mod farmer {
 pub mod node {
     pub use sdk_dsn::*;
     pub use sdk_node::chain_spec::ChainSpec;
-    pub use sdk_node::{chain_spec, domains, Event, RewardsEvent, SubspaceEvent};
+    pub use sdk_node::{
+        chain_spec, domains, BlockNumber, Event, Hash, RewardsEvent, SubspaceEvent, SyncingProgress,
+    };
     pub use sdk_substrate::*;
 
     pub use super::Node;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -13,7 +13,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use anyhow::Context;
-use derive_more::{Deref, DerefMut, Display, From, FromStr, Into};
+use derive_more::{Add, Deref, DerefMut, Display, From, FromStr, Into};
 use futures::prelude::*;
 use jsonrpsee_core::client::{
     BatchResponse, ClientT, Subscription, SubscriptionClientT, SubscriptionKind,
@@ -269,6 +269,7 @@ impl AsyncDropFutures {
 
 /// Container for number of bytes.
 #[derive(
+    Add,
     Clone,
     Copy,
     Debug,

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -13,7 +13,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use anyhow::Context;
-use derive_more::{Add, Deref, DerefMut, Display, From, FromStr, Into};
+use derive_more::{Add, AddAssign, Deref, DerefMut, Display, From, FromStr, Into, Sub, SubAssign};
 use futures::prelude::*;
 use jsonrpsee_core::client::{
     BatchResponse, ClientT, Subscription, SubscriptionClientT, SubscriptionKind,
@@ -270,6 +270,7 @@ impl AsyncDropFutures {
 /// Container for number of bytes.
 #[derive(
     Add,
+    AddAssign,
     Clone,
     Copy,
     Debug,


### PR DESCRIPTION
I need to compute the total space pledged for multi-plot support, this let's me add the custom Bytesize types without trying to unwrap into original `bytesize` and then re-wrapping with custom `bytesize`.

Also with the new construction, some types/structs were not exported for CLI