### PR TITLE
increase node piece cache size to 3 GB

### DIFF
--- a/node/src/builder.rs
+++ b/node/src/builder.rs
@@ -20,7 +20,9 @@ use super::{ChainSpec, Farmer, Node};
 )]
 #[derivative(Default)]
 #[serde(transparent)]
-pub struct PieceCacheSize(#[derivative(Default(value = "ByteSize::gib(1)"))] pub(crate) ByteSize);
+/// Size of cache of pieces that node produces
+/// TODO: Set it to 1 GB once DSN is fixed
+pub struct PieceCacheSize(#[derivative(Default(value = "ByteSize::gib(3)"))] pub(crate) ByteSize);
 
 /// Wrapper with default value for segment publish concurrent jobs
 #[derive(


### PR DESCRIPTION
## Description
This PR sets the default value for node piece cache to 3GB instead of 1GB. This change should be reverted when DSN is fixed.