### PR TITLE
Fix windows clippy job failure

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -84,16 +84,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/bin
-            ~/.cargo/git
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-          key: clippy-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: clippy-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}
-
-      - name: Install cargo utils
-        run: |
-          cargo install cargo-sweep
-          cargo install cargo-cache --no-default-features --features ci-autoclean cargo-cache
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Clean unused crate source checkouts and git repo checkouts
         run: cargo cache

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -90,9 +90,16 @@ jobs:
           restore-keys: clippy-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}
 
       - name: Install utils for caching
+        if: runner.os != 'Windows'
         run: |
           test -x ~/.cargo/bin/cargo-sweep || cargo install cargo-sweep
           test -x ~/.cargo/bin/cargo-cache || cargo install cargo-cache --no-default-features --features ci-autoclean cargo-cache
+
+      - name: Install utils for caching for Windows
+        if: runner.os == 'Windows'
+        run: |
+          test -x ~/.cargo/bin/cargo-sweep.exe || cargo install cargo-sweep
+          test -x ~/.cargo/bin/cargo-cache.exe || cargo install cargo-cache --no-default-features --features ci-autoclean cargo-cache
 
       - name: Clean unused crate source checkouts and git repo checkouts
         run: cargo cache

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -85,6 +85,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/bin
             ~/.cargo/git
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
           key: clippy-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: clippy-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -85,21 +85,13 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/bin
             ~/.cargo/git
-            target
           key: clippy-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: clippy-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}
 
-      - name: Install utils for caching
-        if: runner.os != 'Windows'
+      - name: Install cargo utils
         run: |
-          test -x ~/.cargo/bin/cargo-sweep || cargo install cargo-sweep
-          test -x ~/.cargo/bin/cargo-cache || cargo install cargo-cache --no-default-features --features ci-autoclean cargo-cache
-
-      - name: Install utils for caching for Windows
-        if: runner.os == 'Windows'
-        run: |
-          test -x ~/.cargo/bin/cargo-sweep.exe || cargo install cargo-sweep
-          test -x ~/.cargo/bin/cargo-cache.exe || cargo install cargo-cache --no-default-features --features ci-autoclean cargo-cache
+          cargo install cargo-sweep
+          cargo install cargo-cache --no-default-features --features ci-autoclean cargo-cache
 
       - name: Clean unused crate source checkouts and git repo checkouts
         run: cargo cache


### PR DESCRIPTION
## Description
This PR tries to fix windows clippy job failure by removing the caching of `target` folder and installation of `cargo-cache` and `cargo-sweep` as they are not needed.

## Issue
In `Installing Cache Utilities` step `test`  command was looking for binaries without `exe`  extension and not finding it. So, the command was trying to install the binaries using `cargo install` but failing as cargo was seeing those binary already installed with `exe` extension.

## Solution
Three things were improved:
1. Removal of `target` from caching (which reduces the time it takes to run the caching step)
2. Removed installation of `cargo-sweep` and `cargo-cache` binary as they are not required with `target` caching removed.
3. Simplifying the cache key to `${{ runner.os }}-${{ runner.arch }}`