### PR TITLE
Update the sdk with gemini-3f-2023-sep-13-2 snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,7 +1604,7 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2169,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "domain-block-builder"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "domain-runtime-primitives",
  "parity-scale-codec",
@@ -2210,7 +2210,7 @@ dependencies = [
 [[package]]
 name = "domain-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "async-trait",
  "futures",
@@ -2227,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "domain-client-message-relayer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "async-channel",
  "cross-domain-message-gossip",
@@ -2253,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "domain-client-operator"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "crossbeam",
  "domain-block-builder",
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "domain-client-subnet-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2314,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "domain-eth-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "clap",
  "domain-runtime-primitives",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "domain-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2365,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2381,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "domain-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "async-trait",
  "clap",
@@ -2782,7 +2782,7 @@ dependencies = [
 [[package]]
 name = "evm-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -6507,7 +6507,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6579,7 +6579,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-id"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6591,7 +6591,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6698,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6714,7 +6714,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -6734,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6753,7 +6753,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6768,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6783,7 +6783,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6796,7 +6796,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6808,7 +6808,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6867,7 +6867,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6923,7 +6923,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -8416,7 +8416,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8454,7 +8454,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -8498,7 +8498,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -8829,7 +8829,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "async-trait",
  "futures",
@@ -9046,7 +9046,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -9068,7 +9068,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -10065,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "async-trait",
  "log",
@@ -10182,7 +10182,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10194,7 +10194,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "blake2",
  "hexlit",
@@ -10309,7 +10309,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "frame-support",
  "hash-db 0.16.0",
@@ -10338,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "parity-scale-codec",
  "rayon",
@@ -10801,7 +10801,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "blake2",
  "blake3",
@@ -10826,7 +10826,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "blst_rust",
  "kzg",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10889,7 +10889,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "async-trait",
  "backoff",
@@ -10919,7 +10919,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "domain-block-preprocessor",
  "domain-runtime-primitives",
@@ -10943,7 +10943,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "actix-web",
  "async-mutex",
@@ -10985,7 +10985,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "chacha20 0.9.1",
  "derive_more",
@@ -10998,7 +10998,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "aes 0.8.3",
  "subspace-core-primitives",
@@ -11008,7 +11008,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "hex",
  "serde",
@@ -11020,7 +11020,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -11071,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -11112,7 +11112,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "async-trait",
  "atomic",
@@ -11185,12 +11185,12 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 
 [[package]]
 name = "subspace-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=35ea647d290a051cbc63c289e8506e6b733536b4#35ea647d290a051cbc63c289e8506e6b733536b4"
+source = "git+https://github.com/subspace/subspace?rev=303e99e57b0938082542a1a59f1cc2f875016aff#303e99e57b0938082542a1a59f1cc2f875016aff"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ sdk-substrate = { path = "substrate" }
 sdk-utils = { path = "utils" }
 static_assertions = "1.1.0"
 
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 
 # The only triple tested and confirmed as working in `jemallocator` crate is `x86_64-unknown-linux-gnu`
 [target.'cfg(all(target_arch = "x86_64", target_vendor = "unknown", target_os = "linux", target_env = "gnu"))'.dev-dependencies]
@@ -28,7 +28,7 @@ derive_more = "0.99"
 fdlimit = "0.2"
 futures = "0.3"
 serde_json = "1"
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 tempfile = "3"
 tokio = { version = "1.26", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"

--- a/dsn/Cargo.toml
+++ b/dsn/Cargo.toml
@@ -13,13 +13,13 @@ futures = "0.3"
 hex = "0.4.3"
 parking_lot = "0.12"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 sdk-utils = { path = "../utils" }
 serde = { version = "1", features = ["derive"] }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 tracing = "0.1"
 
 [features]

--- a/farmer/Cargo.toml
+++ b/farmer/Cargo.toml
@@ -18,13 +18,13 @@ pin-project = "1"
 sdk-traits = { path = "../traits" }
 sdk-utils = { path = "../utils" }
 serde = { version = "1", features = ["derive"] }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4", features = ["parallel", "chia"] }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff", features = ["parallel", "chia"] }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 thiserror = "1"
 tokio = { version = "1.28.2", features = ["fs", "rt", "tracing", "macros", "parking_lot", "rt-multi-thread", "signal"] }
 tokio-stream = { version = "0.1", features = ["sync", "time"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,36 +7,36 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 backoff = "0.4"
-cross-domain-message-gossip = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+cross-domain-message-gossip = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 derivative = "2.2.0"
 derive_builder = "0.12"
 derive_more = "0.99"
-domain-client-operator = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-domain-eth-service = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-domain-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-domain-service = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-evm-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+domain-client-operator = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+domain-eth-service = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+domain-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+domain-service = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+evm-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "74483666645e121c0c5e6616f43fdfd8664ea0d3" }
 frame-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 futures = "0.3"
 hex-literal = "0.4"
 once_cell = "1.18.0"
-pallet-rewards = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-pallet-subspace = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+pallet-rewards = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+pallet-subspace = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 parity-scale-codec = "3.6.3"
 parking_lot = "0.12"
 pin-project = "1"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-sc-proof-of-time = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+sc-proof-of-time = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
 sc-storage-monitor = { version = "0.1.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sdk-dsn = { path = "../dsn" }
 sdk-substrate = { path = "../substrate" }
@@ -46,20 +46,20 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-sp-domains = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-sp-messenger = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+sp-domains = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+sp-messenger = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sp-version = { version = "22.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 tokio = { version = "1.28.2", features = ["fs", "rt", "tracing", "macros", "parking_lot", "rt-multi-thread", "signal"] }
 tokio-stream = { version = "0.1", features = ["sync", "time"] }
 tracing = "0.1"

--- a/node/src/builder.rs
+++ b/node/src/builder.rs
@@ -53,6 +53,10 @@ pub struct Config<F: Farmer> {
     #[builder(default)]
     #[serde(default, skip_serializing_if = "sdk_utils::is_default")]
     pub sync_from_dsn: bool,
+    /// DSN Sync parallelism level
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "sdk_utils::is_default")]
+    pub dsn_sync_parallelism_level: usize,
     #[doc(hidden)]
     #[builder(
         setter(into, strip_option),
@@ -107,6 +111,7 @@ impl<F: Farmer + 'static> Builder<F> {
             .dsn(DsnBuilder::dev())
             .rpc(RpcBuilder::dev())
             .offchain_worker(OffchainWorkerBuilder::dev())
+            .dsn_sync_parallelism_level(5)
     }
 
     /// Gemini 3f configuration
@@ -120,6 +125,7 @@ impl<F: Farmer + 'static> Builder<F> {
             .role(Role::Authority)
             .state_pruning(PruningMode::ArchiveAll)
             .blocks_pruning(BlocksPruning::Some(256))
+            .dsn_sync_parallelism_level(5)
     }
 
     /// Devnet chain configuration
@@ -133,6 +139,7 @@ impl<F: Farmer + 'static> Builder<F> {
             .role(Role::Authority)
             .state_pruning(PruningMode::ArchiveAll)
             .blocks_pruning(BlocksPruning::Some(256))
+            .dsn_sync_parallelism_level(5)
     }
 
     /// Get configuration for saving on disk

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -81,7 +81,13 @@ impl<F: Farmer + 'static> Config<F> {
         pot_configuration: PotConfiguration,
     ) -> anyhow::Result<Node<F>> {
         let Self {
-            base, mut dsn, sync_from_dsn, storage_monitor, enable_subspace_block_relay, ..
+            base,
+            mut dsn,
+            sync_from_dsn,
+            storage_monitor,
+            enable_subspace_block_relay,
+            dsn_sync_parallelism_level,
+            ..
         } = self;
 
         let PotConfiguration { is_pot_enabled, is_node_time_keeper } = pot_configuration;
@@ -163,6 +169,7 @@ impl<F: Farmer + 'static> Config<F> {
             subspace_networking,
             sync_from_dsn,
             enable_subspace_block_relay,
+            dsn_sync_parallelism_level,
         };
 
         let node_runner_future = subspace_farmer::utils::run_future_in_dedicated_thread(

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -9,9 +9,9 @@ async-trait = "0.1"
 parking_lot = "0.12"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sdk-dsn = { path = "../dsn" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 
 [features]
 default = []

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3"
 jsonrpsee-core = "0.16"
 libp2p-core = "0.40.0"
 parity-scale-codec = "3.6.3"
-sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
 sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
 sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
@@ -31,11 +31,11 @@ sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate"
 sp-storage = { version = "13.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 ss58-registry = "1.33"
 # Unused for now. TODO: add `serde` feature to `subspace-core-primitives` in `subspace-archiver`
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "35ea647d290a051cbc63c289e8506e6b733536b4" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "303e99e57b0938082542a1a59f1cc2f875016aff" }
 thiserror = "1"
 tokio = { version = "1.28.2", features = ["fs", "rt", "tracing", "macros", "parking_lot", "rt-multi-thread", "signal"] }
 tracing = "0.1"


### PR DESCRIPTION
## Description
This PR updates the sdk to `gemini-3f-2023-sep-13-2` snapshot of monorepo.

## Notable changes:
Addition of `dsn_sync_parallelism_level` parameter with value of 5 for every chain config (`dev`, `devnet` and `gemini3f`)