### PR TITLE
Update Commit Hashes to `sep-29` Release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,7 +1604,7 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2169,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "domain-block-builder"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "domain-runtime-primitives",
  "parity-scale-codec",
@@ -2210,7 +2210,7 @@ dependencies = [
 [[package]]
 name = "domain-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "async-trait",
  "futures",
@@ -2227,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "domain-client-message-relayer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "async-channel",
  "cross-domain-message-gossip",
@@ -2253,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "domain-client-operator"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "crossbeam",
  "domain-block-builder",
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "domain-client-subnet-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2314,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "domain-eth-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "clap",
  "domain-runtime-primitives",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "domain-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2365,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2381,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "domain-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "async-trait",
  "clap",
@@ -2782,7 +2782,7 @@ dependencies = [
 [[package]]
 name = "evm-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -6507,7 +6507,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6579,7 +6579,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-id"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6591,7 +6591,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6698,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6714,7 +6714,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -6734,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6753,7 +6753,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6768,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6783,7 +6783,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6796,7 +6796,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6808,7 +6808,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6867,7 +6867,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6923,7 +6923,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -8416,7 +8416,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8454,7 +8454,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -8499,7 +8499,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "async-trait",
  "futures",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -9069,7 +9069,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -10066,7 +10066,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "async-trait",
  "log",
@@ -10183,7 +10183,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "blake2",
  "hexlit",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "frame-support",
  "hash-db 0.16.0",
@@ -10339,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -10789,7 +10789,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "parity-scale-codec",
  "rayon",
@@ -10802,7 +10802,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "blake2",
  "blake3",
@@ -10827,7 +10827,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "blst_rust",
  "kzg",
@@ -10837,7 +10837,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10856,8 +10856,6 @@ dependencies = [
  "jemallocator",
  "jsonrpsee",
  "lru 0.10.1",
- "memmap2 0.7.1",
- "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -10890,7 +10888,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "async-trait",
  "backoff",
@@ -10920,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "domain-block-preprocessor",
  "domain-runtime-primitives",
@@ -10944,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "actix-web",
  "async-mutex",
@@ -10986,7 +10984,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "chacha20 0.9.1",
  "derive_more",
@@ -10999,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "aes 0.8.3",
  "subspace-core-primitives",
@@ -11009,7 +11007,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "hex",
  "serde",
@@ -11021,7 +11019,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -11072,7 +11070,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -11113,7 +11111,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "async-trait",
  "atomic",
@@ -11186,12 +11184,12 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 
 [[package]]
 name = "subspace-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -11219,7 +11217,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=2d04263a9d44e845b1c92e5ec92e86dfeed0f511#2d04263a9d44e845b1c92e5ec92e86dfeed0f511"
+source = "git+https://github.com/subspace/subspace?rev=d3914a13ea2d5a476b9b93749416ae960f2d105a#d3914a13ea2d5a476b9b93749416ae960f2d105a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ sdk-substrate = { path = "substrate" }
 sdk-utils = { path = "utils" }
 static_assertions = "1.1.0"
 
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 
 # The only triple tested and confirmed as working in `jemallocator` crate is `x86_64-unknown-linux-gnu`
 [target.'cfg(all(target_arch = "x86_64", target_vendor = "unknown", target_os = "linux", target_env = "gnu"))'.dev-dependencies]
@@ -28,7 +28,7 @@ derive_more = "0.99"
 fdlimit = "0.2"
 futures = "0.3"
 serde_json = "1"
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 tempfile = "3"
 tokio = { version = "1.26", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"

--- a/dsn/Cargo.toml
+++ b/dsn/Cargo.toml
@@ -13,13 +13,13 @@ futures = "0.3"
 hex = "0.4.3"
 parking_lot = "0.12"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 sdk-utils = { path = "../utils" }
 serde = { version = "1", features = ["derive"] }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 tracing = "0.1"
 
 [features]

--- a/farmer/Cargo.toml
+++ b/farmer/Cargo.toml
@@ -18,13 +18,13 @@ pin-project = "1"
 sdk-traits = { path = "../traits" }
 sdk-utils = { path = "../utils" }
 serde = { version = "1", features = ["derive"] }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511", features = ["parallel", "chia"] }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a", features = ["parallel", "chia"] }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 thiserror = "1"
 tokio = { version = "1.28.2", features = ["fs", "rt", "tracing", "macros", "parking_lot", "rt-multi-thread", "signal"] }
 tokio-stream = { version = "0.1", features = ["sync", "time"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,36 +7,36 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 backoff = "0.4"
-cross-domain-message-gossip = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+cross-domain-message-gossip = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 derivative = "2.2.0"
 derive_builder = "0.12"
 derive_more = "0.99"
-domain-client-operator = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-domain-eth-service = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-domain-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-domain-service = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-evm-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+domain-client-operator = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+domain-eth-service = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+domain-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+domain-service = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+evm-domain-runtime = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "74483666645e121c0c5e6616f43fdfd8664ea0d3" }
 frame-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 futures = "0.3"
 hex-literal = "0.4"
 once_cell = "1.18.0"
-pallet-rewards = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-pallet-subspace = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+pallet-rewards = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+pallet-subspace = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 parity-scale-codec = "3.6.3"
 parking_lot = "0.12"
 pin-project = "1"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+sc-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-sc-proof-of-time = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+sc-proof-of-time = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
 sc-storage-monitor = { version = "0.1.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sdk-dsn = { path = "../dsn" }
 sdk-substrate = { path = "../substrate" }
@@ -46,20 +46,20 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-sp-domains = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-sp-messenger = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+sp-domains = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+sp-messenger = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sp-version = { version = "22.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 tokio = { version = "1.28.2", features = ["fs", "rt", "tracing", "macros", "parking_lot", "rt-multi-thread", "signal"] }
 tokio-stream = { version = "0.1", features = ["sync", "time"] }
 tracing = "0.1"

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -9,9 +9,9 @@ async-trait = "0.1"
 parking_lot = "0.12"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sdk-dsn = { path = "../dsn" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 
 [features]
 default = []

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3"
 jsonrpsee-core = "0.16"
 libp2p-core = "0.40.0"
 parity-scale-codec = "3.6.3"
-sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+sc-consensus-subspace-rpc = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
 sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
 sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
@@ -31,11 +31,11 @@ sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate"
 sp-storage = { version = "13.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 ss58-registry = "1.33"
 # Unused for now. TODO: add `serde` feature to `subspace-core-primitives` in `subspace-archiver`
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "2d04263a9d44e845b1c92e5ec92e86dfeed0f511" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "d3914a13ea2d5a476b9b93749416ae960f2d105a" }
 thiserror = "1"
 tokio = { version = "1.28.2", features = ["fs", "rt", "tracing", "macros", "parking_lot", "rt-multi-thread", "signal"] }
 tracing = "0.1"


### PR DESCRIPTION
This is to update the SDK to the latest [gemini-3f-2023-sep-29](https://github.com/subspace/subspace/releases/tag/gemini-3f-2023-sep-29) release.