### PR TITLE
Fix `simple.rs` example execution failure

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -6,7 +6,7 @@ use sdk_node::PotConfiguration;
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt().init();
-    let plots = [subspace_sdk::FarmDescription::new("plot", subspace_sdk::ByteSize::mb(100))];
+    let plots = [subspace_sdk::FarmDescription::new("plot", subspace_sdk::ByteSize::mb(1072))];
     let node = subspace_sdk::Node::builder()
         .force_authoring(true)
         .role(subspace_sdk::node::Role::Authority)


### PR DESCRIPTION
## Description

Mentioned in Issue #225 

## Problem

Mentioned in #225 

## Solution

The min. plot/farm size required is `1070780769` i.e. `1070 MB`. So, I modified the plot size with `1072 MB`.